### PR TITLE
feat: support disabling agent retries

### DIFF
--- a/src/adapters/__testing.ts
+++ b/src/adapters/__testing.ts
@@ -1,6 +1,9 @@
 import type z from "zod";
 import type { Tool } from "../tool.ts";
 import type { AsyncStreamItemGenerator, ChatItem } from "../types.ts";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export const testingTracker = new AsyncLocalStorage<{ failures: number }>();
 
 export class TestingAdapter<zO, zI> {
   #tools: Tool<unknown, unknown>[];
@@ -70,6 +73,14 @@ export class TestingAdapter<zO, zI> {
     }
 
     if (lastMessage.type === "tool_result_text") {
+      if (lastMessage.content === "throw") {
+        const store = testingTracker.getStore();
+        if (store) {
+          store.failures += 1;
+        }
+        throw new Error("Deterministic Provider Error");
+      }
+
       return [{
         type: "output_text",
         content: "looks like the tool call got " + lastMessage.content,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -65,7 +65,19 @@ export type AgentOptions<zO, zI, M extends ModelString = ModelString> = {
   output?: z.ZodType<zO, zI>;
   tools?: M extends NoToolCallModels ? never : Tool<any, any>[];
   reasoningEffort?: ReasoningEffort;
+  /**
+   * APIs which are not finalized and are subject to change.
+   */
+  unstable?: UnstableAgentOptions;
 };
+
+export interface UnstableAgentOptions {
+  /**
+   * Set to `false` to disable retrying.
+   * @default true
+   */
+  retries?: boolean;
+}
 
 type AgentRunResultOutput<zO> = unknown extends zO ? undefined : zO;
 export interface AgentRunResult<zO> {
@@ -82,6 +94,8 @@ export class Agent<zO, zI, M extends ModelString> {
   #tools: Tool<any, any>[];
   #reasoningEffort: ReasoningEffort;
 
+  #noRetries = false;
+
   constructor(options: AgentOptions<zO, zI, M>) {
     const [provider, ...modelParts] = options.model.split(":");
     this.#provider = provider;
@@ -90,6 +104,19 @@ export class Agent<zO, zI, M extends ModelString> {
     this.#output = options.output;
     this.#tools = options.tools ?? [];
     this.#reasoningEffort = options.reasoningEffort ?? "normal";
+
+    if (options.unstable) {
+      const { retries = true, ...unknown } = options.unstable;
+      const unknownKeys = Object.keys(unknown);
+      if (unknownKeys.length > 0) {
+        throw new Error(
+          `Unknown unstable options passed: ${
+            unknownKeys.join(", ")
+          }. These options have have been removed in an update.`,
+        );
+      }
+      this.#noRetries = !retries;
+    }
   }
 
   async #runToolUses(toolUses: ChatItemToolUse[], signal: AbortSignal) {
@@ -167,7 +194,7 @@ export class Agent<zO, zI, M extends ModelString> {
           systemPrompt: this.#instructions,
           history: [...history, ...newHistory],
           signal,
-        }), 5);
+        }), this.#noRetries ? 1 : 5);
 
       newHistory.push(...result);
 
@@ -285,6 +312,7 @@ export class Agent<zO, zI, M extends ModelString> {
 
       // If streaming fails halfway through a message, retry
       if (err) {
+        if (this.#noRetries) throw err;
         if (providerErrors < MAX_PROVIDER_ERRORS) {
           providerErrors++;
           // continue loop

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { delay } from "@std/async/delay";
 import { Agent, Tool } from "../mod.ts";
 import { assert, assertEquals, assertRejects } from "@std/assert";
+import { testingTracker } from "../src/adapters/__testing.ts";
 
 Deno.test("Basic input out of agents works", async () => {
   const agent = new Agent({
@@ -181,4 +182,59 @@ Deno.test("Abort signal can work", async () => {
 
   // wait for all delays to clear up so we don't leak timers
   await delay(250);
+});
+
+Deno.test("Agent LLM retries 5 times by default", async () => {
+  const search = new Tool({
+    name: "Searching the internet...",
+    description: "Use when you want to search the internet",
+    parameters: z.string().describe("Query parameter"),
+    execute: () => {
+      return "throw";
+    },
+  });
+
+  const agent = new Agent({
+    model: "__testing:deterministic",
+    instructions: "You are a friendly assistant.",
+    tools: [search],
+  });
+
+  const counter = { failures: 0 };
+  testingTracker.enterWith(counter);
+
+  await assertRejects(
+    () => agent.run("Can you tell me what cat websites there are?"),
+    Error,
+    "Deterministic Provider Error",
+  );
+  assertEquals(counter.failures, 5);
+});
+
+Deno.test("Disable retrying of an agent", async () => {
+  const search = new Tool({
+    name: "Searching the internet...",
+    description: "Use when you want to search the internet",
+    parameters: z.string().describe("Query parameter"),
+    execute: () => {
+      return "throw";
+    },
+  });
+
+  const agent = new Agent({
+    model: "__testing:deterministic",
+    instructions: "You are a friendly assistant.",
+    tools: [search],
+    unstable: { retries: false },
+  });
+
+  const counter = { failures: 0 };
+  testingTracker.enterWith(counter);
+
+  await assertRejects(
+    () => agent.run("Can you tell me what cat websites there are?"),
+    Error,
+    "Deterministic Provider Error",
+  );
+  assertEquals(counter.failures, 1);
 });


### PR DESCRIPTION
we haven't figured a reasonable way to specify model fallbacks in the parameters. the case in question is one where it runs  "openrouter:meta-llama/llama-3.3-70b-instruct" once, then falls back to "google:gemini-2.5-flash". instead of trying openrouter five times, the fallback should be immediate, but representing this in the API is harder, and i'd like to get some dependencies off of other SDKs and just using this library for everythin.