### PR TITLE
fix: OpenResponses/OpenAI structured input/output reliability

### DIFF
--- a/src/adapters/anthropic/adapter.ts
+++ b/src/adapters/anthropic/adapter.ts
@@ -1,20 +1,16 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { assert } from "@std/assert";
-import { type ClassifiedError, createClassifiedError } from "../../errors.ts";
 import { isStructuredOutputRetryFeedback } from "../../constants.ts";
+import { type ClassifiedError, createClassifiedError } from "../../errors.ts";
 import type { AdapterStreamIterator, ChatItem } from "../../types.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
+import type { SchemaCompatibility } from "../shared/schema_compatibility.ts";
 import {
   type AnthropicMessagesStreamConfig,
   type AnthropicModels,
   anthropicModelStructuredOutputSupport,
 } from "./models.ts";
-import {
-  type AnthropicCompatibleSchema,
-  type AnthropicToolMap,
-  createAnthropicCompatibleSchema,
-  normalizeAnthropicTools,
-} from "./utils.ts";
+import { type AnthropicToolMap, createAnthropicCompatibleSchema, normalizeAnthropicTools } from "./utils.ts";
 
 // TODO: drop signature after 10 minutes or whatever
 // Mapping between thinking response and signature since signature is meaningless cross-provider and we technically only need to include thinking for the one step
@@ -131,7 +127,7 @@ export class AnthropicAdapter<TModel extends AnthropicModels> extends Adapter<TM
               type: "tool_use",
               id: historyItem.tool_use_id,
               name: tool?.anthropic.name ?? historyItem.kind,
-              input: tool?.compatibility ? tool.compatibility.toAnthropic(content) : content,
+              input: tool?.compatibility ? tool.compatibility.toProvider(content) : content,
             }],
           });
           break;
@@ -226,7 +222,7 @@ export class AnthropicAdapter<TModel extends AnthropicModels> extends Adapter<TM
     return anthropicHistory;
   }
 
-  getSystemPrompt(instructions: string, structuredOutput?: AnthropicCompatibleSchema): string {
+  getSystemPrompt(instructions: string, structuredOutput?: SchemaCompatibility): string {
     if (!structuredOutput) {
       return instructions;
     }
@@ -343,7 +339,7 @@ ${JSON.stringify(structuredOutput.originalJsonSchema, null, 2)}
           const restoredContent = endingPart.content
             ? JSON.stringify(
               tool?.compatibility
-                ? tool.compatibility.fromAnthropic(JSON.parse(endingPart.content))
+                ? tool.compatibility.fromProvider(JSON.parse(endingPart.content))
                 : JSON.parse(endingPart.content),
             )
             : undefined;
@@ -360,7 +356,7 @@ ${JSON.stringify(structuredOutput.originalJsonSchema, null, 2)}
           let structuredContent: string;
           try {
             structuredContent = JSON.stringify(
-              structuredOutput.fromAnthropic(JSON.parse(rawJson)),
+              structuredOutput.fromProvider(JSON.parse(rawJson)),
             );
           } catch {
             structuredContent = rawJson;

--- a/src/adapters/anthropic/utils.ts
+++ b/src/adapters/anthropic/utils.ts
@@ -1,67 +1,54 @@
 import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages/messages";
 import z from "zod";
-import type { JSONSchema } from "zod/v4/core";
 import type { AnyTool, Tool } from "../../tool.ts";
-
-type ZodJsonSchema = JSONSchema.BaseSchema;
-type ZodJsonSchemaInput = JSONSchema._JSONSchema;
-type JsonValue = NonNullable<ZodJsonSchema["const"]>;
-
-export interface AnthropicCompatibleSchema {
-  /** The original Zod schema used to define the tool's parameters or structured output. */
-  originalJsonSchema: ZodJsonSchema;
-  /** Anthropic-compatible JSON Schema used for structured output or tool input validation. */
-  jsonSchema: ZodJsonSchema;
-  /** Additional prompt instructions required to preserve semantics stripped from the schema. */
-  instructions: string;
-  /** Convert a value in the original schema shape into the Anthropic-compatible surrogate shape. */
-  toAnthropic(value: unknown): unknown;
-  /** Convert a value produced in the Anthropic-compatible surrogate shape back to the original schema shape. */
-  fromAnthropic(value: unknown): unknown;
-}
-
-interface AnthropicCompatibleObjectSchema extends AnthropicCompatibleSchema {
-  jsonSchema: JSONSchema.ObjectSchema;
-}
+import {
+  createSchemaCompatibility,
+  type ObjectSchemaCompatibility,
+  type ObjectSchemaCompatibilityOptions,
+  type SchemaCompatibility,
+  type SchemaCompatibilityFeatures,
+  type SchemaCompatibilityOptions,
+} from "../shared/schema_compatibility.ts";
 
 export type AnthropicToolMap = {
   original: Tool;
   anthropic: AnthropicTool;
-  /** Anthropic-compatible schema and bidirectional conversion for the tool's parameters. */
-  compatibility?: AnthropicCompatibleSchema;
-  /** No parameter specified */
+  compatibility?: SchemaCompatibility;
   isVoid: boolean;
 };
 
-interface CreateAnthropicCompatibleSchemaOptions {
-  kind: "output" | "tool";
-  requireTopLevelObject?: boolean;
-  rootPath: string;
+export interface AnthropicCompatibleSchemaOptions extends Omit<SchemaCompatibilityOptions, "features"> {
+  features?: SchemaCompatibilityFeatures;
 }
 
-interface CreateAnthropicCompatibleObjectSchemaOptions extends CreateAnthropicCompatibleSchemaOptions {
-  requireTopLevelObject: true;
+interface AnthropicCompatibleObjectSchemaOptions extends Omit<ObjectSchemaCompatibilityOptions, "features"> {
+  features?: SchemaCompatibilityFeatures;
 }
 
-interface CompatibilityNode {
-  jsonSchema: ZodJsonSchema;
-  toAnthropic(value: unknown): unknown;
-  fromAnthropic(value: unknown): unknown;
-}
-
-interface ObjectCompatibilityNode extends CompatibilityNode {
-  jsonSchema: JSONSchema.ObjectSchema;
-}
-
-interface TransformContext {
-  constraints: string[];
-  usedRecord: boolean;
-  usedDynamicRecordFallback: boolean;
-  usedTuple: boolean;
-}
-
-const INTEGER_BOUNDS =
-  `within the JavaScript safe integer range (${Number.MIN_SAFE_INTEGER} to ${Number.MAX_SAFE_INTEGER})`;
+export const anthropicSchemaCompatibilityFeatures: SchemaCompatibilityFeatures = {
+  tuples: {
+    strategy: "object-surrogate",
+    itemKeyPrefix: "item",
+    restKey: "rest",
+  },
+  records: {
+    finite: "explicit-object",
+    dynamic: "entries-array",
+    keyPropertyName: "key",
+    valuePropertyName: "value",
+  },
+  strings: {
+    length: "instructions",
+  },
+  numbers: {
+    integerType: "number",
+    bounds: "instructions",
+    multipleOf: "instructions",
+  },
+  arrays: {
+    length: "min1-only",
+  },
+};
 
 export function normalizeAnthropicTools(tools: AnyTool[]): AnthropicToolMap[] {
   return tools.map((tool): AnthropicToolMap => {
@@ -94,7 +81,7 @@ export function normalizeAnthropicTools(tools: AnyTool[]): AnthropicToolMap[] {
         strict: true,
         eager_input_streaming: true,
         input_schema: compatibleSchema.jsonSchema,
-        description: compatibleSchema?.instructions
+        description: compatibleSchema.instructions
           ? `${tool.description}\n\n${compatibleSchema.instructions}`
           : tool.description,
       },
@@ -104,699 +91,20 @@ export function normalizeAnthropicTools(tools: AnyTool[]): AnthropicToolMap[] {
   });
 }
 
-/**
- * Converts a Zod schema into an Anthropic-compatible contract while preserving
- * the original logical shape for the rest of the app.
- *
- * Why this exists:
- * Anthropic structured output accepts a restricted JSON Schema subset. Some
- * shapes that are valid and useful in our original Zod schema are awkward or
- * unsupported there, especially:
- * - dynamic records (`Record<string, T>`) because they rely on  `additionalProperties`
- * - tuples (`[A, B, ...]`) because they rely on `prefixItems`
- * - min and max constraints on strings, numbers, and arrays because they rely on keywords like `minLength`, `maxLength` etc.
- *   - This also made integer schemas unsupported because zod automatically attaches MIN_SAFE_INTEGER and MAX_SAFE_INTEGER bounds to them
- * - constraints we still care about but cannot or do not want to enforce purely through Anthropic's accepted schema subset
- *
- * What this function returns:
- * - `jsonSchema`: the provider-facing schema we actually send to Anthropic
- * - `instructions`: extra prompt guidance describing any semantics moved out of the schema
- * - `toAnthropic`: converts an original-shape value into the surrogate shape Anthropic expects
- * - `fromAnthropic`: restores Anthropic's surrogate output back into the original logical shape before the Agent validates it with the original Zod schema
- *
- * In practice, this lets the provider work with a simplified JSON Schema while
- * the rest of the system continues to think in terms of the original schema.
- * @example
- * ```ts
- * const compatibility = createAnthropicCompatibleSchema(
- *   z.object({ tags: z.record(z.string(), z.string()) }),
- *   { kind: "output", rootPath: "output" },
- * );
- *
- * compatibility.toAnthropic({ tags: { a: "1" } });
- * // => { tags: [{ key: "a", value: "1" }] }
- *
- * compatibility.fromAnthropic({ tags: [{ key: "a", value: "1" }] });
- * // => { tags: { a: "1" } }
- * ```
- */
 export function createAnthropicCompatibleSchema(
   schema: z.ZodType,
-  options: CreateAnthropicCompatibleObjectSchemaOptions,
-): AnthropicCompatibleObjectSchema;
+  options: AnthropicCompatibleObjectSchemaOptions,
+): ObjectSchemaCompatibility;
 export function createAnthropicCompatibleSchema(
   schema: z.ZodType,
-  options: CreateAnthropicCompatibleSchemaOptions,
-): AnthropicCompatibleSchema;
-
+  options: AnthropicCompatibleSchemaOptions,
+): SchemaCompatibility;
 export function createAnthropicCompatibleSchema(
   schema: z.ZodType,
-  options: CreateAnthropicCompatibleSchemaOptions,
-): AnthropicCompatibleSchema {
-  const originalJsonSchema = z.toJSONSchema(schema);
-  const context: TransformContext = {
-    constraints: [],
-    usedRecord: false,
-    usedDynamicRecordFallback: false,
-    usedTuple: false,
-  };
-
-  const root = transformSchemaNode(originalJsonSchema, options.rootPath, context);
-
-  if (!options.requireTopLevelObject) {
-    return {
-      originalJsonSchema,
-      jsonSchema: root.jsonSchema,
-      instructions: buildInstructions(context, options.kind),
-      toAnthropic: root.toAnthropic,
-      fromAnthropic: root.fromAnthropic,
-    };
-  }
-
-  if (isObjectLikeSchema(root.jsonSchema)) {
-    return {
-      originalJsonSchema,
-      jsonSchema: root.jsonSchema,
-      instructions: buildInstructions(context, options.kind),
-      toAnthropic: root.toAnthropic,
-      fromAnthropic: root.fromAnthropic,
-    };
-  }
-
-  const compatibility = wrapTopLevel(root);
-
-  return {
-    originalJsonSchema,
-    jsonSchema: compatibility.jsonSchema,
-    instructions: buildInstructions(context, options.kind),
-    toAnthropic: compatibility.toAnthropic,
-    fromAnthropic: compatibility.fromAnthropic,
-  };
-}
-
-function transformSchemaNode(
-  schema: ZodJsonSchemaInput | undefined,
-  path: string,
-  context: TransformContext,
-): CompatibilityNode {
-  const normalizedSchema = isJsonSchema(schema) ? schema : {};
-
-  if (Array.isArray(normalizedSchema.anyOf) && normalizedSchema.anyOf.length > 0) {
-    return transformAnyOfSchema(normalizedSchema, path, context);
-  }
-
-  if (Array.isArray(normalizedSchema.prefixItems) && normalizedSchema.prefixItems.length > 0) {
-    return transformTupleSchema(normalizedSchema, path, context);
-  }
-
-  if (isRecordSchema(normalizedSchema)) {
-    return transformRecordSchema(normalizedSchema, path, context);
-  }
-
-  switch (getPrimaryType(normalizedSchema)) {
-    case "object":
-      return transformObjectSchema(normalizedSchema, path, context);
-    case "array":
-      return transformArraySchema(normalizedSchema, path, context);
-    case "integer":
-    case "number":
-      return transformNumberSchema(normalizedSchema, path, context);
-    case "string":
-      return transformStringSchema(normalizedSchema, path, context);
-    default:
-      return identityNode(normalizedSchema);
-  }
-}
-
-function transformAnyOfSchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  const options = schema.anyOf ?? [];
-  const nodes = options.map((option, index) => transformSchemaNode(option, `${path}[option ${index}]`, context));
-
-  return {
-    jsonSchema: {
-      ...preserveMeta(schema),
-      anyOf: nodes.map((node) => node.jsonSchema),
-    },
-    toAnthropic(value) {
-      const index = options.findIndex((option) => matchesSchema(value, option));
-      return index === -1 ? value : nodes[index].toAnthropic(value);
-    },
-    fromAnthropic(value) {
-      const index = nodes.findIndex((node) => matchesSchema(value, node.jsonSchema));
-      return index === -1 ? value : nodes[index].fromAnthropic(value);
-    },
-  };
-}
-
-function transformObjectSchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  const propertyEntries = Object.entries(schema.properties ?? {});
-  const nodes = Object.fromEntries(
-    propertyEntries.map(([key, value]) => [key, transformSchemaNode(value, `${path}.${key}`, context)]),
-  );
-
-  return {
-    jsonSchema: {
-      ...preserveMeta(schema),
-      type: "object",
-      properties: Object.fromEntries(Object.entries(nodes).map(([key, node]) => [key, node.jsonSchema])),
-      required: schema.required,
-      additionalProperties: false,
-    },
-    toAnthropic(value) {
-      if (!isPlainObject(value)) return value;
-      const result: Record<string, unknown> = {};
-      for (const [key, node] of Object.entries(nodes)) {
-        if (key in value) result[key] = node.toAnthropic(value[key]);
-      }
-      return result;
-    },
-    fromAnthropic(value) {
-      if (!isPlainObject(value)) return value;
-      const result: Record<string, unknown> = {};
-      for (const [key, node] of Object.entries(nodes)) {
-        if (key in value) result[key] = node.fromAnthropic(value[key]);
-      }
-      return result;
-    },
-  };
-}
-
-function transformArraySchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  const itemNode = transformSchemaNode(Array.isArray(schema.items) ? undefined : schema.items, `${path}[]`, context);
-  const constraints: string[] = [];
-  const minItems = typeof schema.minItems === "number" ? schema.minItems : undefined;
-  const maxItems = typeof schema.maxItems === "number" ? schema.maxItems : undefined;
-
-  if (minItems !== undefined && maxItems !== undefined && minItems === maxItems) {
-    constraints.push(`exactly ${minItems} item${minItems === 1 ? "" : "s"}`);
-  } else {
-    if (minItems !== undefined && minItems > 1) {
-      constraints.push(`at least ${minItems} item${minItems === 1 ? "" : "s"}`);
-    }
-    if (maxItems !== undefined) constraints.push(`at most ${maxItems} item${maxItems === 1 ? "" : "s"}`);
-  }
-
-  if (constraints.length > 0) {
-    context.constraints.push(`- \`${path}\` must contain ${constraints.join(" and ")}`);
-  }
-
-  const transformed: ZodJsonSchema = {
-    ...preserveMeta(schema),
-    type: "array",
-    items: itemNode.jsonSchema,
-  };
-  if (minItems === 1) transformed.minItems = 1;
-
-  return {
-    jsonSchema: transformed,
-    toAnthropic(value) {
-      return Array.isArray(value) ? value.map((item) => itemNode.toAnthropic(item)) : value;
-    },
-    fromAnthropic(value) {
-      return Array.isArray(value) ? value.map((item) => itemNode.fromAnthropic(item)) : value;
-    },
-  };
-}
-
-function transformNumberSchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  const constraints: string[] = [];
-
-  if (getPrimaryType(schema) === "integer") {
-    constraints.push("an integer");
-    if (schema.minimum === Number.MIN_SAFE_INTEGER && schema.maximum === Number.MAX_SAFE_INTEGER) {
-      constraints.push(INTEGER_BOUNDS);
-    }
-  }
-
-  if (
-    typeof schema.minimum === "number" &&
-    !(schema.minimum === Number.MIN_SAFE_INTEGER && schema.maximum === Number.MAX_SAFE_INTEGER)
-  ) {
-    constraints.push(`>= ${schema.minimum}`);
-  }
-  if (
-    typeof schema.maximum === "number" &&
-    !(schema.minimum === Number.MIN_SAFE_INTEGER && schema.maximum === Number.MAX_SAFE_INTEGER)
-  ) {
-    constraints.push(`<= ${schema.maximum}`);
-  }
-  if (typeof schema.multipleOf === "number") constraints.push(`a multiple of ${schema.multipleOf}`);
-
-  if (constraints.length > 0) {
-    context.constraints.push(`- \`${path}\` must be ${constraints.join(", ")}`);
-  }
-
-  return {
-    jsonSchema: {
-      ...preserveMeta(schema),
-      type: "number",
-    },
-    toAnthropic: identity,
-    fromAnthropic: identity,
-  };
-}
-
-function transformStringSchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  const constraints: string[] = [];
-  const minLength = typeof schema.minLength === "number" ? schema.minLength : undefined;
-  const maxLength = typeof schema.maxLength === "number" ? schema.maxLength : undefined;
-
-  if (minLength !== undefined && maxLength !== undefined && minLength === maxLength) {
-    constraints.push(`exactly ${minLength} character${minLength === 1 ? "" : "s"}`);
-  } else {
-    if (minLength !== undefined) constraints.push(`at least ${minLength} character${minLength === 1 ? "" : "s"}`);
-    if (maxLength !== undefined) constraints.push(`at most ${maxLength} character${maxLength === 1 ? "" : "s"}`);
-  }
-
-  if (constraints.length > 0) {
-    context.constraints.push(`- \`${path}\` must have ${constraints.join(" and ")}`);
-  }
-
-  const transformed = structuredClone(schema);
-  delete transformed.minLength;
-  delete transformed.maxLength;
-  return {
-    jsonSchema: transformed,
-    toAnthropic: identity,
-    fromAnthropic: identity,
-  };
-}
-
-function transformRecordSchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  context.usedRecord = true;
-
-  const keyInfo = getFinitePropertyNames(schema.propertyNames);
-  const additionalProperties = isJsonSchema(schema.additionalProperties) ? schema.additionalProperties : {};
-  const valueNode = transformSchemaNode(additionalProperties, `${path}.*`, context);
-  const keyType = schemaTypeToString(schema.propertyNames);
-  const valueType = schemaTypeToString(additionalProperties);
-  context.constraints.push(`- \`${path}\` is a \`Record<${keyType}, ${valueType}>\``);
-
-  if (keyInfo) {
-    const required = keyInfo.partial ? undefined : keyInfo.keys;
-    return {
-      jsonSchema: {
-        ...preserveMeta(schema),
-        type: "object",
-        properties: Object.fromEntries(keyInfo.keys.map((key) => [key, valueNode.jsonSchema])),
-        required,
-        additionalProperties: false,
-      },
-      toAnthropic(value) {
-        if (!isPlainObject(value)) return value;
-        const result: Record<string, unknown> = {};
-        for (const key of keyInfo.keys) {
-          if (key in value) result[key] = valueNode.toAnthropic(value[key]);
-        }
-        return result;
-      },
-      fromAnthropic(value) {
-        if (!isPlainObject(value)) return value;
-        const result: Record<string, unknown> = {};
-        for (const key of keyInfo.keys) {
-          if (key in value) result[key] = valueNode.fromAnthropic(value[key]);
-        }
-        return result;
-      },
-    };
-  }
-
-  context.usedDynamicRecordFallback = true;
-  const keySchema = transformPropertyNameSchema(schema.propertyNames);
-  return {
-    jsonSchema: {
-      ...preserveMeta(schema),
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          key: keySchema,
-          value: valueNode.jsonSchema,
-        },
-        required: ["key", "value"],
-        additionalProperties: false,
-      },
-    },
-    toAnthropic(value) {
-      if (!isPlainObject(value)) return value;
-      return Object.entries(value).map(([key, entryValue]) => ({
-        key: coerceKeyFromObject(key, schema.propertyNames),
-        value: valueNode.toAnthropic(entryValue),
-      }));
-    },
-    fromAnthropic(value) {
-      if (!Array.isArray(value)) return value;
-      const result: Record<string, unknown> = {};
-      for (const entry of value) {
-        if (!isPlainObject(entry) || !("key" in entry)) continue;
-        result[String(entry.key)] = valueNode.fromAnthropic(entry.value);
-      }
-      return result;
-    },
-  };
-}
-
-function transformTupleSchema(schema: ZodJsonSchema, path: string, context: TransformContext): CompatibilityNode {
-  context.usedTuple = true;
-  const itemNodes = (schema.prefixItems ?? []).map((item, index) =>
-    transformSchemaNode(item, `${path}.item${index}`, context)
-  );
-  const restNode = isJsonSchema(schema.items)
-    ? transformSchemaNode(schema.items, `${path}.rest[]`, context)
-    : undefined;
-  context.constraints.push(`- \`${path}\` is a Tuple \`${schemaTypeToString(schema)}\``);
-
-  const properties: Record<string, ZodJsonSchema> = {};
-  const required: string[] = [];
-  for (let index = 0; index < itemNodes.length; index++) {
-    properties[`item${index}`] = itemNodes[index].jsonSchema;
-    required.push(`item${index}`);
-  }
-  if (restNode) properties.rest = { type: "array", items: restNode.jsonSchema };
-
-  return {
-    jsonSchema: {
-      ...preserveMeta(schema),
-      type: "object",
-      properties,
-      required,
-      additionalProperties: false,
-    },
-    toAnthropic(value) {
-      if (!Array.isArray(value)) return value;
-      const result: Record<string, unknown> = {};
-      for (let index = 0; index < itemNodes.length; index++) {
-        result[`item${index}`] = itemNodes[index].toAnthropic(value[index]);
-      }
-      if (restNode && value.length > itemNodes.length) {
-        result.rest = value.slice(itemNodes.length).map((item) => restNode.toAnthropic(item));
-      }
-      return result;
-    },
-    fromAnthropic(value) {
-      if (!isPlainObject(value)) return value;
-      const result = itemNodes.map((node, index) => node.fromAnthropic(value[`item${index}`]));
-      if (restNode && Array.isArray(value.rest)) {
-        result.push(...value.rest.map((item) => restNode.fromAnthropic(item)));
-      }
-      return result;
-    },
-  };
-}
-
-function wrapTopLevel(root: CompatibilityNode): ObjectCompatibilityNode {
-  return {
-    jsonSchema: {
-      type: "object",
-      properties: { content: root.jsonSchema },
-      required: ["content"],
-      additionalProperties: false,
-    },
-    toAnthropic(value) {
-      return { content: root.toAnthropic(value) };
-    },
-    fromAnthropic(value) {
-      return isPlainObject(value) ? root.fromAnthropic(value.content) : root.fromAnthropic(value);
-    },
-  };
-}
-
-function buildInstructions(context: TransformContext, kind: "output" | "tool"): string {
-  if (context.constraints.length === 0 && !context.usedRecord && !context.usedTuple) return "";
-
-  const glossary: string[] = [];
-  if (context.usedTuple) {
-    glossary.push(
-      "Tuple - An ordered fixed-length sequence. In the Anthropic-compatible schema it is represented as an object with keys `item0`, `item1`, etc. If the tuple has a rest element, it appears under `rest`.",
-    );
-  }
-  if (context.usedRecord) {
-    glossary.push(
-      context.usedDynamicRecordFallback
-        ? "Record - A key-value map. Finite-key records are represented as explicit objects. Dynamic records are represented as arrays of `{ key, value }` objects because Anthropic does not allow `additionalProperties` schemas."
-        : "Record - A key-value map. Finite-key records are represented as explicit objects in the Anthropic-compatible schema.",
-    );
-  }
-
-  if (kind === "output") {
-    return `\
-<output_requirements>
-Your final output must conform to the provided JSON Schema, and additionally satisfy the following requirements:
-${context.constraints.length > 0 ? context.constraints.join("\n") : ""}
-${glossary.length > 0 ? "\n\n" + glossary.join("\n") : ""}
-</output_requirements>
-`;
-  }
-
-  return `\
-<input_requirements>
-Tool arguments must conform to the provided JSON Schema, and additionally satisfy the following requirements:
-${context.constraints.length > 0 ? context.constraints.join("\n") : ""}
-${glossary.length > 0 ? "\n\n" + glossary.join("\n") : ""}
-</input_requirements>
-`;
-}
-
-function transformPropertyNameSchema(schema: ZodJsonSchemaInput | undefined): ZodJsonSchema {
-  if (!isJsonSchema(schema)) return { type: "string" };
-
-  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
-    return {
-      ...preserveMeta(schema),
-      anyOf: schema.anyOf
-        .filter((option) => !isNeverSchema(option))
-        .map((option) => stripUnsupportedKeywords(option)),
-    };
-  }
-
-  return stripUnsupportedKeywords(schema);
-}
-
-function stripUnsupportedKeywords(schema: ZodJsonSchema): ZodJsonSchema {
-  const stripped: ZodJsonSchema = Object.fromEntries(
-    Object.entries(schema).flatMap(([key, value]) => {
-      switch (key) {
-        case "minimum":
-        case "maximum":
-        case "multipleOf":
-        case "minLength":
-        case "maxLength":
-        case "maxItems":
-          return [];
-        case "minItems":
-          return value === 1 ? [[key, value]] : [];
-        case "items":
-          if (isJsonSchema(value)) return [[key, stripUnsupportedKeywords(value)]];
-          if (Array.isArray(value)) {
-            return [[key, value.map((item) => isJsonSchema(item) ? stripUnsupportedKeywords(item) : item)]];
-          }
-          return [[key, value]];
-        case "anyOf":
-          return [[key, Array.isArray(value) ? value.map((option) => stripUnsupportedKeywords(option)) : value]];
-        case "prefixItems":
-          return [[
-            key,
-            Array.isArray(value)
-              ? value.map((option) => isJsonSchema(option) ? stripUnsupportedKeywords(option) : option)
-              : value,
-          ]];
-        case "properties":
-          return [[
-            key,
-            isPlainObject(value)
-              ? Object.fromEntries(
-                Object.entries(value).map(([propertyKey, propertyValue]) => [
-                  propertyKey,
-                  isJsonSchema(propertyValue) ? stripUnsupportedKeywords(propertyValue) : propertyValue,
-                ]),
-              )
-              : value,
-          ]];
-        case "additionalProperties":
-        case "propertyNames":
-          return [[key, isJsonSchema(value) ? stripUnsupportedKeywords(value) : value]];
-        default:
-          return [[key, value]];
-      }
-    }),
-  );
-
-  return stripped;
-}
-
-function identity(value: unknown): unknown {
-  return value;
-}
-
-function identityNode(schema: ZodJsonSchema): CompatibilityNode {
-  return {
-    jsonSchema: stripUnsupportedKeywords(schema),
-    toAnthropic: identity,
-    fromAnthropic: identity,
-  };
-}
-
-function getPrimaryType(schema: ZodJsonSchema): string | undefined {
-  return Array.isArray(schema.type) ? schema.type[0] : schema.type;
-}
-
-function isJsonSchema(value: unknown): value is ZodJsonSchema {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isObjectLikeSchema(schema: ZodJsonSchema): schema is JSONSchema.ObjectSchema {
-  return getPrimaryType(schema) === "object" || !!schema.properties;
-}
-
-function isRecordSchema(schema: ZodJsonSchema): boolean {
-  return getPrimaryType(schema) === "object" && isJsonSchema(schema.additionalProperties);
-}
-
-function isNeverSchema(schema: ZodJsonSchema): boolean {
-  return isJsonSchema(schema.not) && Object.keys(schema.not).length === 0;
-}
-
-function getFinitePropertyNames(schema: ZodJsonSchemaInput | undefined): { keys: string[]; partial: boolean } | null {
-  if (!isJsonSchema(schema)) return null;
-
-  if (
-    Array.isArray(schema.enum) && schema.enum.every((value) => typeof value === "string" || typeof value === "number")
-  ) {
-    return { keys: schema.enum.map(String), partial: false };
-  }
-
-  if ((typeof schema.const === "string" || typeof schema.const === "number")) {
-    return { keys: [String(schema.const)], partial: false };
-  }
-
-  if (Array.isArray(schema.anyOf)) {
-    let partial = false;
-    const keys: string[] = [];
-    for (const option of schema.anyOf) {
-      if (isNeverSchema(option)) {
-        partial = true;
-        continue;
-      }
-      const nested = getFinitePropertyNames(option);
-      if (!nested || nested.partial) return null;
-      keys.push(...nested.keys);
-    }
-    return keys.length > 0 ? { keys: [...new Set(keys)], partial } : null;
-  }
-
-  return null;
-}
-
-function schemaTypeToString(schema: ZodJsonSchemaInput | ZodJsonSchemaInput[] | undefined): string {
-  if (schema === false) return "never";
-  if (schema === true || schema === undefined) return "unknown";
-  if (Array.isArray(schema)) {
-    return schema.map((item) => schemaTypeToString(item)).join(" | ");
-  }
-  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
-    return schema.anyOf.map((option) => schemaTypeToString(option)).join(" | ");
-  }
-  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
-    return schema.enum.map((value) => JSON.stringify(value)).join(" | ");
-  }
-  if (schema.const !== undefined) return JSON.stringify(schema.const);
-  if (Array.isArray(schema.prefixItems)) {
-    const items = schema.prefixItems.map((item) => schemaTypeToString(item));
-    if (schema.items) return `[${items.join(", ")}, ...${schemaTypeToString(schema.items)}[]]`;
-    return `[${items.join(", ")}]`;
-  }
-
-  const type = getPrimaryType(schema);
-  switch (type) {
-    case "object": {
-      if (isJsonSchema(schema.additionalProperties)) {
-        return `Record<${schemaTypeToString(schema.propertyNames)}, ${
-          schemaTypeToString(schema.additionalProperties)
-        }>`;
-      }
-      return "object";
-    }
-    case "array":
-      return `${schemaTypeToString(schema.items)}[]`;
-    case "integer":
-      return "integer";
-    case "number":
-    case "string":
-    case "boolean":
-    case "null":
-      return type;
-    default:
-      return "unknown";
-  }
-}
-
-function preserveMeta(schema: ZodJsonSchema): ZodJsonSchema {
-  const meta: ZodJsonSchema = {};
-  if (schema.description !== undefined) meta.description = schema.description;
-  if (schema.title !== undefined) meta.title = schema.title;
-  if (schema.default !== undefined) meta.default = schema.default;
-  return meta;
-}
-
-function matchesSchema(value: unknown, schema: ZodJsonSchemaInput | undefined): boolean {
-  if (schema === false) return false;
-  if (schema === true || schema === undefined) return true;
-
-  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
-    return schema.anyOf.some((option) => matchesSchema(value, option));
-  }
-
-  if (Array.isArray(schema.enum)) return schema.enum.some((candidate) => candidate === value);
-  if (schema.const !== undefined) return schema.const === value;
-
-  if (Array.isArray(schema.prefixItems)) return isPlainObject(value);
-
-  switch (getPrimaryType(schema)) {
-    case "object":
-      return isPlainObject(value);
-    case "array":
-      return Array.isArray(value);
-    case "integer":
-      return typeof value === "number" && Number.isInteger(value);
-    case "number":
-      return typeof value === "number";
-    case "string":
-      return typeof value === "string";
-    case "boolean":
-      return typeof value === "boolean";
-    case "null":
-      return value === null;
-    default:
-      return true;
-  }
-}
-
-function coerceKeyFromObject(key: string, propertyNames: ZodJsonSchemaInput | undefined): JsonValue {
-  if (!isJsonSchema(propertyNames)) return key;
-
-  if (Array.isArray(propertyNames.anyOf)) {
-    for (const option of propertyNames.anyOf) {
-      if (isNeverSchema(option)) continue;
-      const coerced = coerceKeyFromObject(key, option);
-      if (matchesSchema(coerced, option)) return coerced;
-    }
-    return key;
-  }
-
-  if (getPrimaryType(propertyNames) === "number" || getPrimaryType(propertyNames) === "integer") {
-    const numeric = Number(key);
-    return Number.isNaN(numeric) ? key : numeric;
-  }
-  if ((typeof propertyNames.const === "string" || typeof propertyNames.const === "number")) {
-    return propertyNames.const;
-  }
-  if (Array.isArray(propertyNames.enum)) {
-    const match = propertyNames.enum.find((candidate) => String(candidate) === key);
-    return match ?? key;
-  }
-  return key;
+  options: AnthropicCompatibleSchemaOptions,
+): SchemaCompatibility {
+  return createSchemaCompatibility(schema, {
+    ...options,
+    features: options.features ?? anthropicSchemaCompatibilityFeatures,
+  });
 }

--- a/src/adapters/open_responses/adapter.ts
+++ b/src/adapters/open_responses/adapter.ts
@@ -12,8 +12,10 @@ import type {
 import type { ReasoningEffort } from "openai/resources/shared";
 
 import { isStructuredOutputRetryFeedback, RETRY_RESUMABILITY_PROMPT } from "../../constants.ts";
+import type { ClassifiedError } from "../../errors.ts";
 import type { AdapterStreamIterator, ChatItem } from "../../types.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
+import { classifyOpenAIError } from "../shared/classify_error.ts";
 import {
   DEFAULT_SUPPORTED_MIME_TYPES,
   fetchRemoteFileAsDataUrl,
@@ -25,10 +27,15 @@ import {
   supportsMimeType,
   unsupportedMediaTypeError,
 } from "../shared/media.ts";
+import { createOpenAICompatibleSchema } from "../shared/openai_compatibility.ts";
 import { restoreWrappedToolArguments, serializeWrappedToolArguments } from "../shared/tools.ts";
-import { classifyOpenAIError } from "../shared/classify_error.ts";
 import { normalizeOpenResponsesTools, type OpenResponsesToolMap } from "./tools.ts";
-import type { ClassifiedError } from "../../errors.ts";
+
+interface PendingToolCall {
+  tool_use_id: string;
+  kind: string;
+  tool?: OpenResponsesToolMap;
+}
 
 type FileHistoryItem = Extract<ChatItem, { type: "input_file" } | { type: "tool_result_file" }>;
 
@@ -241,21 +248,33 @@ export class OpenResponsesAdapter<TModel extends string> extends Adapter<TModel>
     { history, instructions, tools, signal, output }: AdapterStreamOptions<zO, zI>,
   ): AdapterStreamIterator {
     const normalizedTools = normalizeOpenResponsesTools(tools);
+    const structuredOutput = output && createOpenAICompatibleSchema(output, {
+      kind: "output",
+      rootPath: "output",
+    });
+    const shouldRestoreStructuredOutput = structuredOutput?.requiresValueTransformation ?? false;
     const responseHistory = await this.getHistory(history, normalizedTools, signal);
-    const toolByName = new Map(normalizedTools.map((tool) => [tool.openResponses.name, tool]));
-    const pendingToolCallsByOutputIndex = new Map<number, { tool_use_id: string; kind: string }>();
-    const pendingToolCallsByItemId = new Map<string, { tool_use_id: string; kind: string }>();
+    const pendingToolCallsByOutputIndex: PendingToolCall[] = [];
+    const pendingToolCallsByItemId: Record<string, PendingToolCall> = {};
+    const pendingStructuredOutput: string[] = [];
 
     const request: OpenResponsesStreamingRequest = {
       model: this.model,
       input: responseHistory,
-      instructions,
+      instructions: structuredOutput?.instructions
+        ? `${structuredOutput.instructions}\n\n${instructions}`
+        : instructions,
       parallel_tool_calls: this.#parallelToolCalls,
       service_tier: this.#serviceTier,
       tools: normalizedTools.map((tool) => tool.openResponses),
       text: {
-        format: output
-          ? { type: "json_schema", name: "output", strict: true, schema: output.toJSONSchema() }
+        format: structuredOutput
+          ? {
+            type: "json_schema",
+            name: "output",
+            strict: true,
+            schema: structuredOutput.jsonSchema,
+          }
           : { type: "text" },
       },
       reasoning: this.#reasoning,
@@ -269,11 +288,16 @@ export class OpenResponsesAdapter<TModel extends string> extends Adapter<TModel>
         case "response.output_text.delta":
         case "response.refusal.delta":
           if (part.delta) {
-            yield {
-              type: "delta_output_text",
-              delta: part.delta,
-              index: part.output_index,
-            };
+            if (shouldRestoreStructuredOutput) {
+              pendingStructuredOutput[part.output_index] ??= "";
+              pendingStructuredOutput[part.output_index] += part.delta;
+            } else {
+              yield {
+                type: "delta_output_text",
+                delta: part.delta,
+                index: part.output_index,
+              };
+            }
           }
           break;
         case "response.reasoning_summary_text.delta":
@@ -286,38 +310,74 @@ export class OpenResponsesAdapter<TModel extends string> extends Adapter<TModel>
             };
           }
           break;
-        case "response.output_item.added":
-          if (part.item.type === "function_call") {
-            const tool = toolByName.get(part.item.name);
-            const pendingToolCall = {
-              tool_use_id: part.item.call_id,
-              kind: tool?.original.name ?? part.item.name,
-            };
-            pendingToolCallsByOutputIndex.set(part.output_index, pendingToolCall);
-            if (part.item.id) {
-              pendingToolCallsByItemId.set(part.item.id, pendingToolCall);
-            }
+        case "response.output_item.added": {
+          const item = part.item;
+          if (item.type !== "function_call") break;
+
+          const tool = normalizedTools.find((candidate) => candidate.openResponses.name === item.name);
+          const pendingToolCall: PendingToolCall = {
+            tool_use_id: item.call_id,
+            kind: tool?.original.name ?? item.name,
+            tool,
+          };
+          pendingToolCallsByOutputIndex[part.output_index] = pendingToolCall;
+          if (item.id) {
+            pendingToolCallsByItemId[item.id] = pendingToolCall;
+          }
+          yield {
+            type: "tool_use_start",
+            index: part.output_index,
+            tool_use_id: pendingToolCall.tool_use_id,
+            kind: pendingToolCall.kind,
+          };
+          break;
+        }
+        case "response.function_call_arguments.done": {
+          const pendingToolCall = pendingToolCallsByItemId[part.item_id] ??
+            pendingToolCallsByOutputIndex[part.output_index];
+          const tool = pendingToolCall?.tool ??
+            normalizedTools.find((candidate) => candidate.openResponses.name === part.name);
+          const toolUseId = pendingToolCall?.tool_use_id ?? part.item_id;
+          const kind = pendingToolCall?.kind ?? tool?.original.name ?? part.name;
+
+          if (!pendingToolCall) {
             yield {
               type: "tool_use_start",
               index: part.output_index,
-              tool_use_id: pendingToolCall.tool_use_id,
-              kind: pendingToolCall.kind,
+              tool_use_id: toolUseId,
+              kind,
             };
           }
-          break;
-        case "response.function_call_arguments.done": {
-          const pendingToolCall = pendingToolCallsByItemId.get(part.item_id) ??
-            pendingToolCallsByOutputIndex.get(part.output_index);
-          const tool = toolByName.get(part.name);
+
           yield {
             type: "tool_use",
             index: part.output_index,
-            tool_use_id: pendingToolCall?.tool_use_id ?? part.item_id,
-            kind: pendingToolCall?.kind ?? tool?.original.name ?? part.name,
+            tool_use_id: toolUseId,
+            kind,
             content: restoreWrappedToolArguments(part.arguments, tool),
           };
           break;
         }
+      }
+    }
+
+    if (shouldRestoreStructuredOutput) {
+      for (let index = 0; index < pendingStructuredOutput.length; index++) {
+        const rawText = pendingStructuredOutput[index];
+        if (!rawText) continue;
+
+        let restoredText = rawText;
+        try {
+          restoredText = JSON.stringify(structuredOutput!.fromProvider(JSON.parse(rawText)));
+        } catch {
+          restoredText = rawText;
+        }
+
+        yield {
+          type: "delta_output_text",
+          delta: restoredText,
+          index,
+        };
       }
     }
 

--- a/src/adapters/open_responses/tools.ts
+++ b/src/adapters/open_responses/tools.ts
@@ -1,10 +1,13 @@
 import type { FunctionTool } from "openai/resources/responses/responses";
 import z from "zod";
 import type { AnyTool } from "../../tool.ts";
+import { createOpenAICompatibleSchema } from "../shared/openai_compatibility.ts";
+import type { SchemaCompatibility } from "../shared/schema_compatibility.ts";
 
 export interface OpenResponsesToolMap {
   original: AnyTool;
   openResponses: FunctionTool;
+  compatibility?: SchemaCompatibility;
   /** Open Responses function tools expect object-shaped params, so non-objects are wrapped under `content`. */
   wrapperObject: boolean;
   /** No parameter specified. */
@@ -23,22 +26,31 @@ export function normalizeOpenResponsesTools(tools: AnyTool[]): OpenResponsesTool
           parameters: z.object({}).toJSONSchema(),
           strict: false,
         },
+        compatibility: undefined,
         wrapperObject: false,
         isVoid: true,
       };
     }
 
     const wrapperObject = !(tool.parameters instanceof z.ZodObject);
+    const compatibility = createOpenAICompatibleSchema(tool.parameters, {
+      kind: "tool",
+      requireTopLevelObject: true,
+      rootPath: "input",
+    });
 
     return {
       original: tool,
       openResponses: {
         type: "function",
         name: tool.normalizedName,
-        description: tool.description,
+        description: compatibility.instructions
+          ? `${tool.description}\n\n${compatibility.instructions}`
+          : tool.description,
         strict: false,
-        parameters: z.toJSONSchema(wrapperObject ? z.object({ content: tool.parameters }) : tool.parameters),
+        parameters: compatibility.jsonSchema,
       },
+      compatibility,
       wrapperObject,
       isVoid: false,
     };

--- a/src/adapters/openai_completions/adapter.ts
+++ b/src/adapters/openai_completions/adapter.ts
@@ -4,10 +4,11 @@ import type {
   ChatCompletionMessageParam,
 } from "openai/resources/chat/completions";
 import type z from "zod";
-import { classifyOpenAIError } from "../shared/classify_error.ts";
 import { isStructuredOutputRetryFeedback, RETRY_RESUMABILITY_PROMPT } from "../../constants.ts";
+import type { ClassifiedError } from "../../errors.ts";
 import type { AdapterStreamIterator, ChatItem, ChatItemInputFile, ChatItemToolResultFile } from "../../types.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
+import { classifyOpenAIError } from "../shared/classify_error.ts";
 import {
   DEFAULT_SUPPORTED_MIME_TYPES,
   fetchPdfAsText,
@@ -21,9 +22,17 @@ import {
   supportsMimeType,
   unsupportedMediaTypeError,
 } from "../shared/media.ts";
+import { createOpenAICompatibleSchema } from "../shared/openai_compatibility.ts";
 import { restoreWrappedToolArguments, serializeWrappedToolArguments } from "../shared/tools.ts";
+
 import { normalizeOpenAICompletionsTools, type OpenAICompletionsToolMap } from "./tools.ts";
-import type { ClassifiedError } from "../../errors.ts";
+
+interface PendingToolUse {
+  streamIndex: number | null;
+  callId?: string;
+  name?: string;
+  content: string;
+}
 
 type FileHistoryItem = ChatItemInputFile | ChatItemToolResultFile;
 export type OpenAICompletionsClient = Pick<OpenAI, "chat">;
@@ -253,8 +262,15 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
     { history, instructions, tools, signal, output }: AdapterStreamOptions<zO, zI>,
   ): AdapterStreamIterator {
     const normalizedTools = normalizeOpenAICompletionsTools(tools);
-    const messages = await this.getHistory(history, instructions, normalizedTools, signal);
-    const toolByName = new Map(normalizedTools.map((tool) => [tool.openAI.function.name, tool]));
+    const structuredOutput = output && createOpenAICompatibleSchema(output, {
+      kind: "output",
+      rootPath: "output",
+    });
+    const shouldRestoreStructuredOutput = structuredOutput?.requiresValueTransformation ?? false;
+    const fullInstructions = structuredOutput?.instructions
+      ? `${structuredOutput.instructions}\n\n${instructions}`
+      : instructions;
+    const messages = await this.getHistory(history, fullInstructions, normalizedTools, signal);
 
     const extraRequestBody = resolveOpenAICompletionsExtraRequestBody(this.#extraRequestBody, {
       model: this.model,
@@ -267,13 +283,13 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
       messages,
       parallel_tool_calls: normalizedTools.length > 0 ? this.#parallelToolCalls : undefined,
       tools: normalizedTools.length > 0 ? normalizedTools.map((tool) => tool.openAI) : undefined,
-      response_format: output
+      response_format: structuredOutput
         ? {
           type: "json_schema",
           json_schema: {
             name: "output",
             strict: true,
-            schema: output.toJSONSchema(),
+            schema: structuredOutput.jsonSchema,
           },
         }
         : { type: "text" },
@@ -287,12 +303,9 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
 
     const response = this.#client.chat.completions.stream(request, { signal });
 
-    const pendingToolUses = new Map<number, {
-      streamIndex: number | null;
-      callId?: string;
-      name?: string;
-      content: string;
-    }>();
+    const pendingToolUses: PendingToolUse[] = [];
+    const startedToolUses: PendingToolUse[] = [];
+    const pendingStructuredOutput: string[] = [];
 
     let lastType = "";
     let lastIndex = -1;
@@ -329,25 +342,31 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
           lastIndex++;
         }
 
-        yield {
-          type: "delta_output_text",
-          index: lastIndex,
-          delta: delta.content,
-        };
+        if (shouldRestoreStructuredOutput) {
+          pendingStructuredOutput[lastIndex] ??= "";
+          pendingStructuredOutput[lastIndex] += delta.content;
+        } else {
+          yield {
+            type: "delta_output_text",
+            index: lastIndex,
+            delta: delta.content,
+          };
+        }
       }
 
       for (const call of delta.tool_calls ?? []) {
         const callIndex = call.index ?? 0;
-        const pending = pendingToolUses.get(callIndex) ?? { streamIndex: null, content: "" };
+        const pending = pendingToolUses[callIndex] ?? { streamIndex: null, content: "" };
 
         if (call.id) pending.callId = call.id;
         if (call.function?.name) pending.name = call.function.name;
         if (call.function?.arguments) pending.content += call.function.arguments;
 
         if (pending.streamIndex === null && pending.callId && pending.name) {
-          const tool = toolByName.get(pending.name);
+          const tool = normalizedTools.find((candidate) => candidate.openAI.function.name === pending.name);
           pending.streamIndex = ++lastIndex;
           lastType = "tool_use";
+          startedToolUses.push(pending);
 
           yield {
             type: "tool_use_start",
@@ -357,17 +376,13 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
           };
         }
 
-        pendingToolUses.set(callIndex, pending);
+        pendingToolUses[callIndex] = pending;
       }
     }
 
-    for (
-      const pending of [...pendingToolUses.values()].sort((left, right) =>
-        (left.streamIndex ?? 0) - (right.streamIndex ?? 0)
-      )
-    ) {
+    for (const pending of startedToolUses) {
       if (pending.streamIndex === null || !pending.callId || !pending.name) continue;
-      const tool = toolByName.get(pending.name);
+      const tool = normalizedTools.find((candidate) => candidate.openAI.function.name === pending.name);
 
       yield {
         type: "tool_use",
@@ -376,6 +391,26 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
         kind: tool?.original.name ?? pending.name,
         content: restoreWrappedToolArguments(pending.content, tool),
       };
+    }
+
+    if (shouldRestoreStructuredOutput) {
+      for (let index = 0; index < pendingStructuredOutput.length; index++) {
+        const rawText = pendingStructuredOutput[index];
+        if (rawText === undefined) continue;
+
+        let restoredText = rawText;
+        try {
+          restoredText = JSON.stringify(structuredOutput!.fromProvider(JSON.parse(rawText)));
+        } catch {
+          restoredText = rawText;
+        }
+
+        yield {
+          type: "delta_output_text",
+          index,
+          delta: restoredText,
+        };
+      }
     }
 
     const usage = await response.totalUsage();

--- a/src/adapters/openai_completions/tools.ts
+++ b/src/adapters/openai_completions/tools.ts
@@ -1,5 +1,7 @@
 import z from "zod";
 import type { AnyTool } from "../../tool.ts";
+import { createOpenAICompatibleSchema } from "../shared/openai_compatibility.ts";
+import type { SchemaCompatibility } from "../shared/schema_compatibility.ts";
 
 interface FunctionTool {
   type: "function";
@@ -14,6 +16,7 @@ interface FunctionTool {
 export interface OpenAICompletionsToolMap {
   original: AnyTool;
   openAI: FunctionTool;
+  compatibility?: SchemaCompatibility;
   wrapperObject: boolean;
   isVoid: boolean;
 }
@@ -36,12 +39,18 @@ export function normalizeOpenAICompletionsTools(tools: AnyTool[]): OpenAIComplet
             strict: false,
           },
         },
+        compatibility: undefined,
         wrapperObject: false,
         isVoid: true,
       };
     }
 
     const wrapperObject = !(tool.parameters instanceof z.ZodObject);
+    const compatibility = createOpenAICompatibleSchema(tool.parameters, {
+      kind: "tool",
+      requireTopLevelObject: true,
+      rootPath: "input",
+    });
 
     return {
       original: tool,
@@ -49,11 +58,14 @@ export function normalizeOpenAICompletionsTools(tools: AnyTool[]): OpenAIComplet
         type: "function",
         function: {
           name: tool.normalizedName,
-          description: tool.description,
+          description: compatibility.instructions
+            ? `${tool.description}\n\n${compatibility.instructions}`
+            : tool.description,
           strict: true,
-          parameters: z.toJSONSchema(wrapperObject ? z.object({ content: tool.parameters }) : tool.parameters),
+          parameters: compatibility.jsonSchema,
         },
       },
+      compatibility,
       wrapperObject,
       isVoid: false,
     };

--- a/src/adapters/shared/openai_compatibility.ts
+++ b/src/adapters/shared/openai_compatibility.ts
@@ -1,0 +1,61 @@
+import type z from "zod";
+import {
+  createSchemaCompatibility,
+  type ObjectSchemaCompatibility,
+  type ObjectSchemaCompatibilityOptions,
+  type SchemaCompatibility,
+  type SchemaCompatibilityFeatures,
+  type SchemaCompatibilityOptions,
+} from "./schema_compatibility.ts";
+
+export interface OpenAICompatibleSchemaOptions extends Omit<SchemaCompatibilityOptions, "features"> {
+  features?: SchemaCompatibilityFeatures;
+}
+
+interface OpenAICompatibleObjectSchemaOptions extends Omit<ObjectSchemaCompatibilityOptions, "features"> {
+  features?: SchemaCompatibilityFeatures;
+}
+
+export const openAISchemaCompatibilityFeatures: SchemaCompatibilityFeatures = {
+  tuples: {
+    strategy: "object-surrogate",
+    itemKeyPrefix: "item",
+    restKey: "rest",
+  },
+  records: {
+    finite: "explicit-object",
+    dynamic: "entries-array",
+    keyPropertyName: "key",
+    valuePropertyName: "value",
+  },
+  strings: {
+    length: "instructions",
+  },
+  numbers: {
+    integerType: "number",
+    bounds: "instructions",
+    multipleOf: "instructions",
+  },
+  arrays: {
+    length: "min1-only",
+  },
+};
+
+export function createOpenAICompatibleSchema(
+  schema: z.ZodType,
+  options: OpenAICompatibleObjectSchemaOptions,
+): ObjectSchemaCompatibility;
+export function createOpenAICompatibleSchema(
+  schema: z.ZodType,
+  options: OpenAICompatibleSchemaOptions,
+): SchemaCompatibility;
+
+export function createOpenAICompatibleSchema(
+  schema: z.ZodType,
+  options: OpenAICompatibleSchemaOptions,
+): SchemaCompatibility {
+  return createSchemaCompatibility(schema, {
+    ...options,
+    features: options.features ?? openAISchemaCompatibilityFeatures,
+  });
+}

--- a/src/adapters/shared/schema_compatibility.ts
+++ b/src/adapters/shared/schema_compatibility.ts
@@ -1,0 +1,919 @@
+import z from "zod";
+import type { JSONSchema } from "zod/v4/core";
+
+export type ZodJsonSchema = JSONSchema.BaseSchema;
+export type ZodJsonSchemaInput = JSONSchema._JSONSchema;
+type JsonValue = NonNullable<ZodJsonSchema["const"]>;
+
+export interface SchemaCompatibility {
+  /** The original JSON Schema produced directly from the Zod schema. */
+  originalJsonSchema: ZodJsonSchema;
+  /** Provider-compatible JSON Schema after compatibility rewriting. */
+  jsonSchema: ZodJsonSchema;
+  /** Prompt instructions that preserve constraints moved out of the JSON Schema. */
+  instructions: string;
+  /** Whether values need shape conversion before sending to, or after receiving from, the provider. */
+  requiresValueTransformation: boolean;
+  /** Converts a value from the original application-facing shape into the provider-facing shape described by `jsonSchema`. */
+  toProvider(value: unknown): unknown;
+  /** Converts a provider-produced value back into the original application-facingshape before the original Zod schema validates it. */
+  fromProvider(value: unknown): unknown;
+}
+
+export interface ObjectSchemaCompatibility extends SchemaCompatibility {
+  jsonSchema: JSONSchema.ObjectSchema;
+}
+
+/**
+ * Describes which schema features a provider can represent directly and which
+ * ones need to be moved into prompt instructions or surrogate shapes.
+ */
+export interface SchemaCompatibilityFeatures {
+  tuples: {
+    strategy: "native" | "object-surrogate";
+    itemKeyPrefix?: string;
+    restKey?: string;
+  };
+  records: {
+    finite: "native" | "explicit-object";
+    dynamic: "native" | "entries-array";
+    keyPropertyName?: string;
+    valuePropertyName?: string;
+  };
+  strings: {
+    length: "native" | "instructions";
+  };
+  numbers: {
+    integerType: "native" | "number";
+    bounds: "native" | "instructions";
+    multipleOf: "native" | "instructions";
+  };
+  arrays: {
+    length: "native" | "min1-only" | "instructions";
+  };
+}
+
+export interface SchemaCompatibilityOptions {
+  kind: "output" | "tool";
+  requireTopLevelObject?: boolean;
+  rootPath: string;
+  features: SchemaCompatibilityFeatures;
+}
+
+export interface ObjectSchemaCompatibilityOptions extends SchemaCompatibilityOptions {
+  requireTopLevelObject: true;
+}
+
+interface CompatibilityNode {
+  jsonSchema: ZodJsonSchema;
+  toProvider(value: unknown): unknown;
+  fromProvider(value: unknown): unknown;
+}
+
+interface ObjectCompatibilityNode extends CompatibilityNode {
+  jsonSchema: JSONSchema.ObjectSchema;
+}
+
+interface CompatibilityContext {
+  constraints: string[];
+  usedRecord: boolean;
+  usedDynamicRecordFallback: boolean;
+  usedTupleSurrogate: boolean;
+  features: SchemaCompatibilityFeatures;
+}
+
+/**
+ * Converts a Zod schema into a provider-compatible contract while keeping the
+ * rest of the application working with the original logical shape.
+ *
+ * Why this exists:
+ * Some providers only accept a restricted JSON Schema subset.
+ * Useful shapes like tuples, dynamic records, non-object top-level values, and length or
+ * numeric constraints may need to be rewritten into a simpler schema plus a small amount of prompt guidance.
+ *
+ * What this returns:
+ * - `jsonSchema`: the provider-facing schema to send upstream
+ * - `instructions`: prompt text for semantics that no longer fit in schema form
+ * - `toProvider`: converts original values into the provider-facing schema shape
+ * - `fromProvider`: restores provider values back into the original application shape
+ */
+export function createSchemaCompatibility(
+  schema: z.ZodType,
+  options: ObjectSchemaCompatibilityOptions,
+): ObjectSchemaCompatibility;
+export function createSchemaCompatibility(schema: z.ZodType, options: SchemaCompatibilityOptions): SchemaCompatibility;
+export function createSchemaCompatibility(schema: z.ZodType, options: SchemaCompatibilityOptions): SchemaCompatibility {
+  const originalJsonSchema = z.toJSONSchema(schema);
+  const context = createCompatibilityContext(options.features);
+
+  const root = transformSchemaNode(originalJsonSchema, options.rootPath, context);
+  const compatibility = shouldWrapTopLevelObject(options.requireTopLevelObject, root.jsonSchema)
+    ? wrapTopLevel(root)
+    : root;
+  const requiresValueTransformation = context.usedTupleSurrogate || context.usedDynamicRecordFallback ||
+    compatibility !== root;
+
+  return {
+    originalJsonSchema,
+    jsonSchema: compatibility.jsonSchema,
+    instructions: buildInstructions(context, options.kind),
+    requiresValueTransformation,
+    toProvider: compatibility.toProvider,
+    fromProvider: compatibility.fromProvider,
+  };
+}
+
+function transformSchemaNode(
+  schema: ZodJsonSchemaInput | undefined,
+  path: string,
+  context: CompatibilityContext,
+): CompatibilityNode {
+  const normalizedSchema = isJsonSchema(schema) ? schema : {};
+
+  if (Array.isArray(normalizedSchema.anyOf) && normalizedSchema.anyOf.length > 0) {
+    return transformAnyOfSchema(normalizedSchema, path, context);
+  }
+
+  if (Array.isArray(normalizedSchema.prefixItems) && normalizedSchema.prefixItems.length > 0) {
+    return context.features.tuples.strategy === "native"
+      ? transformNativeTupleSchema(normalizedSchema, path, context)
+      : transformTupleSchema(normalizedSchema, path, context);
+  }
+
+  if (isRecordSchema(normalizedSchema)) {
+    return transformRecordSchema(normalizedSchema, path, context);
+  }
+
+  switch (getPrimaryType(normalizedSchema)) {
+    case "object":
+      return transformObjectSchema(normalizedSchema, path, context);
+    case "array":
+      return transformArraySchema(normalizedSchema, path, context);
+    case "integer":
+    case "number":
+      return transformNumberSchema(normalizedSchema, path, context);
+    case "string":
+      return transformStringSchema(normalizedSchema, path, context);
+    default:
+      return identityNode(normalizedSchema, context);
+  }
+}
+
+function transformAnyOfSchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  const options = schema.anyOf ?? [];
+  const nodes = options.map((option, index) => transformSchemaNode(option, `${path}[option ${index}]`, context));
+
+  return {
+    jsonSchema: {
+      ...preserveSchemaMetadata(schema),
+      anyOf: nodes.map((node) => node.jsonSchema),
+    },
+    toProvider(value) {
+      const index = options.findIndex((option) => matchesSchema(value, option, context));
+      return index === -1 ? value : nodes[index].toProvider(value);
+    },
+    fromProvider(value) {
+      const index = nodes.findIndex((node) => matchesSchema(value, node.jsonSchema, context));
+      return index === -1 ? value : nodes[index].fromProvider(value);
+    },
+  };
+}
+
+function transformObjectSchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  const propertyEntries = Object.entries(schema.properties ?? {});
+  const nodes = Object.fromEntries(
+    propertyEntries.map(([key, value]) => [key, transformSchemaNode(value, `${path}.${key}`, context)]),
+  );
+
+  return {
+    jsonSchema: {
+      ...preserveSchemaMetadata(schema),
+      type: "object",
+      properties: Object.fromEntries(Object.entries(nodes).map(([key, node]) => [key, node.jsonSchema])),
+      required: schema.required,
+      additionalProperties: false,
+    },
+    toProvider(value) {
+      if (!isPlainObject(value)) return value;
+      const result: Record<string, unknown> = {};
+      for (const [key, node] of Object.entries(nodes)) {
+        if (key in value) result[key] = node.toProvider(value[key]);
+      }
+      return result;
+    },
+    fromProvider(value) {
+      if (!isPlainObject(value)) return value;
+      const result: Record<string, unknown> = {};
+      for (const [key, node] of Object.entries(nodes)) {
+        if (key in value) result[key] = node.fromProvider(value[key]);
+      }
+      return result;
+    },
+  };
+}
+
+function transformArraySchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  const itemNode = transformSchemaNode(Array.isArray(schema.items) ? undefined : schema.items, `${path}[]`, context);
+  const constraints: string[] = [];
+  const minItems = typeof schema.minItems === "number" ? schema.minItems : undefined;
+  const maxItems = typeof schema.maxItems === "number" ? schema.maxItems : undefined;
+  const { length } = context.features.arrays;
+
+  if (length !== "native") {
+    if (minItems !== undefined && maxItems !== undefined && minItems === maxItems) {
+      constraints.push(`exactly ${minItems} item${minItems === 1 ? "" : "s"}`);
+    } else {
+      if (minItems !== undefined && (length === "instructions" || minItems > 1)) {
+        constraints.push(`at least ${minItems} item${minItems === 1 ? "" : "s"}`);
+      }
+      if (maxItems !== undefined) constraints.push(`at most ${maxItems} item${maxItems === 1 ? "" : "s"}`);
+    }
+  }
+
+  if (constraints.length > 0) {
+    context.constraints.push(`- \`${path}\` must contain ${constraints.join(" and ")}`);
+  }
+
+  const transformed = {
+    ...omitSchemaKeywords(schema, getArrayKeywordsToOmit(length, minItems)),
+    items: itemNode.jsonSchema,
+  };
+
+  return {
+    jsonSchema: transformed,
+    toProvider(value) {
+      return Array.isArray(value) ? value.map((item) => itemNode.toProvider(item)) : value;
+    },
+    fromProvider(value) {
+      return Array.isArray(value) ? value.map((item) => itemNode.fromProvider(item)) : value;
+    },
+  };
+}
+
+function transformNumberSchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  const constraints: string[] = [];
+  const { integerType, bounds, multipleOf } = context.features.numbers;
+  const hasRedundantSafeIntegerBounds = isRedundantSafeIntegerBounds(schema);
+
+  if (getPrimaryType(schema) === "integer" && integerType === "number") {
+    constraints.push("an integer");
+  }
+
+  if (bounds === "instructions") {
+    if (typeof schema.minimum === "number" && !hasRedundantSafeIntegerBounds) {
+      constraints.push(`>= ${schema.minimum}`);
+    }
+    if (typeof schema.maximum === "number" && !hasRedundantSafeIntegerBounds) {
+      constraints.push(`<= ${schema.maximum}`);
+    }
+  }
+
+  if (multipleOf === "instructions" && typeof schema.multipleOf === "number") {
+    constraints.push(`a multiple of ${schema.multipleOf}`);
+  }
+
+  const transformed: ZodJsonSchema = {
+    ...omitSchemaKeywords(
+      schema,
+      getNumberKeywordsToOmit({
+        bounds,
+        multipleOf,
+        hasRedundantSafeIntegerBounds,
+      }),
+    ),
+    ...(getPrimaryType(schema) === "integer" && integerType === "number" ? { type: "number" } : {}),
+  };
+
+  if (constraints.length > 0) {
+    context.constraints.push(`- \`${path}\` must be ${constraints.join(", ")}`);
+  }
+
+  return {
+    jsonSchema: transformed,
+    toProvider: identity,
+    fromProvider: identity,
+  };
+}
+
+function transformStringSchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  const constraints: string[] = [];
+  const minLength = typeof schema.minLength === "number" ? schema.minLength : undefined;
+  const maxLength = typeof schema.maxLength === "number" ? schema.maxLength : undefined;
+
+  if (context.features.strings.length === "instructions") {
+    if (minLength !== undefined && maxLength !== undefined && minLength === maxLength) {
+      constraints.push(`exactly ${minLength} character${minLength === 1 ? "" : "s"}`);
+    } else {
+      if (minLength !== undefined) {
+        constraints.push(`at least ${minLength} character${minLength === 1 ? "" : "s"}`);
+      }
+      if (maxLength !== undefined) {
+        constraints.push(`at most ${maxLength} character${maxLength === 1 ? "" : "s"}`);
+      }
+    }
+  }
+
+  const transformed = context.features.strings.length === "instructions"
+    ? omitSchemaKeywords(schema, ["minLength", "maxLength"])
+    : { ...schema };
+
+  if (constraints.length > 0) {
+    context.constraints.push(`- \`${path}\` must have ${constraints.join(" and ")}`);
+  }
+
+  return {
+    jsonSchema: transformed,
+    toProvider: identity,
+    fromProvider: identity,
+  };
+}
+
+function transformRecordSchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  context.usedRecord = true;
+
+  const keyInfo = getFinitePropertyNames(schema.propertyNames);
+  const additionalProperties = isJsonSchema(schema.additionalProperties) ? schema.additionalProperties : {};
+  const valueNode = transformSchemaNode(additionalProperties, `${path}.*`, context);
+  const keyType = schemaTypeToString(schema.propertyNames);
+  const valueType = schemaTypeToString(additionalProperties);
+  context.constraints.push(`- \`${path}\` is a \`Record<${keyType}, ${valueType}>\``);
+
+  if (keyInfo && context.features.records.finite === "explicit-object") {
+    const required = keyInfo.partial ? undefined : keyInfo.keys;
+    return {
+      jsonSchema: {
+        ...preserveSchemaMetadata(schema),
+        type: "object",
+        properties: Object.fromEntries(keyInfo.keys.map((key) => [key, valueNode.jsonSchema])),
+        required,
+        additionalProperties: false,
+      },
+      toProvider(value) {
+        if (!isPlainObject(value)) return value;
+        const result: Record<string, unknown> = {};
+        for (const key of keyInfo.keys) {
+          if (key in value) result[key] = valueNode.toProvider(value[key]);
+        }
+        return result;
+      },
+      fromProvider(value) {
+        if (!isPlainObject(value)) return value;
+        const result: Record<string, unknown> = {};
+        for (const key of keyInfo.keys) {
+          if (key in value) result[key] = valueNode.fromProvider(value[key]);
+        }
+        return result;
+      },
+    };
+  }
+
+  if (context.features.records.dynamic === "entries-array" && !keyInfo) {
+    context.usedDynamicRecordFallback = true;
+    const keyPropertyName = context.features.records.keyPropertyName ?? "key";
+    const valuePropertyName = context.features.records.valuePropertyName ?? "value";
+    const keySchema = transformPropertyNameSchema(schema.propertyNames, context);
+
+    return {
+      jsonSchema: {
+        ...preserveSchemaMetadata(schema),
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            [keyPropertyName]: keySchema,
+            [valuePropertyName]: valueNode.jsonSchema,
+          },
+          required: [keyPropertyName, valuePropertyName],
+          additionalProperties: false,
+        },
+      },
+      toProvider(value) {
+        if (!isPlainObject(value)) return value;
+        return Object.entries(value).map(([key, entryValue]) => ({
+          [keyPropertyName]: coerceKeyFromObject(key, schema.propertyNames, context),
+          [valuePropertyName]: valueNode.toProvider(entryValue),
+        }));
+      },
+      fromProvider(value) {
+        if (!Array.isArray(value)) return value;
+        const result: Record<string, unknown> = {};
+        for (const entry of value) {
+          // Ignore malformed provider entries here and let the final Zod parse decide validity.
+          if (!isPlainObject(entry) || !(keyPropertyName in entry)) continue;
+          result[String(entry[keyPropertyName])] = valueNode.fromProvider(entry[valuePropertyName]);
+        }
+        return result;
+      },
+    };
+  }
+
+  return {
+    jsonSchema: {
+      ...preserveSchemaMetadata(schema),
+      type: "object",
+      propertyNames: transformPropertyNameSchema(schema.propertyNames, context),
+      additionalProperties: valueNode.jsonSchema,
+    },
+    toProvider(value) {
+      if (!isPlainObject(value)) return value;
+      return Object.fromEntries(
+        Object.entries(value).map(([key, entryValue]) => [key, valueNode.toProvider(entryValue)]),
+      );
+    },
+    fromProvider(value) {
+      if (!isPlainObject(value)) return value;
+      return Object.fromEntries(
+        Object.entries(value).map(([key, entryValue]) => [key, valueNode.fromProvider(entryValue)]),
+      );
+    },
+  };
+}
+
+function transformNativeTupleSchema(
+  schema: ZodJsonSchema,
+  path: string,
+  context: CompatibilityContext,
+): CompatibilityNode {
+  const itemNodes = (schema.prefixItems ?? []).map((item, index) =>
+    transformSchemaNode(item, `${path}[${index}]`, context)
+  );
+  const restNode = isJsonSchema(schema.items) ? transformSchemaNode(schema.items, `${path}[rest]`, context) : undefined;
+  const transformed = structuredClone(schema);
+  transformed.prefixItems = itemNodes.map((node) => node.jsonSchema);
+  transformed.items = restNode?.jsonSchema ?? schema.items;
+
+  return {
+    jsonSchema: transformed,
+    toProvider(value) {
+      if (!Array.isArray(value)) return value;
+      return value.map((item, index) => {
+        const node = itemNodes[index] ?? restNode;
+        return node ? node.toProvider(item) : item;
+      });
+    },
+    fromProvider(value) {
+      if (!Array.isArray(value)) return value;
+      return value.map((item, index) => {
+        const node = itemNodes[index] ?? restNode;
+        return node ? node.fromProvider(item) : item;
+      });
+    },
+  };
+}
+
+function transformTupleSchema(schema: ZodJsonSchema, path: string, context: CompatibilityContext): CompatibilityNode {
+  context.usedTupleSurrogate = true;
+  const itemNodes = (schema.prefixItems ?? []).map((item, index) =>
+    transformSchemaNode(item, `${path}.${context.features.tuples.itemKeyPrefix ?? "item"}${index}`, context)
+  );
+  const restNode = isJsonSchema(schema.items)
+    ? transformSchemaNode(schema.items, `${path}.${context.features.tuples.restKey ?? "rest"}[]`, context)
+    : undefined;
+  context.constraints.push(`- \`${path}\` is a Tuple \`${schemaTypeToString(schema)}\``);
+
+  const itemKeyPrefix = context.features.tuples.itemKeyPrefix ?? "item";
+  const restKey = context.features.tuples.restKey ?? "rest";
+  const properties: Record<string, ZodJsonSchema> = {};
+  const required: string[] = [];
+
+  for (let index = 0; index < itemNodes.length; index++) {
+    properties[`${itemKeyPrefix}${index}`] = itemNodes[index].jsonSchema;
+    required.push(`${itemKeyPrefix}${index}`);
+  }
+
+  if (restNode) {
+    properties[restKey] = { type: "array", items: restNode.jsonSchema };
+  }
+
+  return {
+    jsonSchema: {
+      ...preserveSchemaMetadata(schema),
+      type: "object",
+      properties,
+      required,
+      additionalProperties: false,
+    },
+    toProvider(value) {
+      if (!Array.isArray(value)) return value;
+
+      const result: Record<string, unknown> = {};
+      for (let index = 0; index < itemNodes.length; index++) {
+        result[`${itemKeyPrefix}${index}`] = itemNodes[index].toProvider(value[index]);
+      }
+      if (restNode && value.length > itemNodes.length) {
+        // Only emit the surrogate `rest` field when the tuple actually has overflow items.
+        result[restKey] = value.slice(itemNodes.length).map((item) => restNode.toProvider(item));
+      }
+      return result;
+    },
+    fromProvider(value) {
+      if (!isPlainObject(value)) return value;
+      const result = itemNodes.map((node, index) => node.fromProvider(value[`${itemKeyPrefix}${index}`]));
+      if (restNode && Array.isArray(value[restKey])) {
+        result.push(...value[restKey].map((item) => restNode.fromProvider(item)));
+      }
+      return result;
+    },
+  };
+}
+
+function wrapTopLevel(root: CompatibilityNode): ObjectCompatibilityNode {
+  return {
+    jsonSchema: {
+      type: "object",
+      properties: { content: root.jsonSchema },
+      required: ["content"],
+      additionalProperties: false,
+    },
+    toProvider(value) {
+      return { content: root.toProvider(value) };
+    },
+    fromProvider(value) {
+      return isPlainObject(value) ? root.fromProvider(value.content) : root.fromProvider(value);
+    },
+  };
+}
+
+function buildInstructions(
+  context: CompatibilityContext,
+  kind: "output" | "tool",
+): string {
+  const glossary = getInstructionGlossary(context);
+
+  if (context.constraints.length === 0 && glossary.length === 0) return "";
+
+  const { tag, intro } = getInstructionEnvelope(kind);
+  const body = [
+    context.constraints.length > 0 ? context.constraints.join("\n") : "",
+    glossary.length > 0 ? glossary.join("\n") : "",
+  ].filter(Boolean).join("\n\n");
+
+  return `\
+<${tag}>
+${intro}
+${body}
+</${tag}>
+`;
+}
+
+function transformPropertyNameSchema(
+  schema: ZodJsonSchemaInput | undefined,
+  context: CompatibilityContext,
+): ZodJsonSchema {
+  if (!isJsonSchema(schema)) return { type: "string" };
+
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+    return {
+      ...preserveSchemaMetadata(schema),
+      anyOf: schema.anyOf
+        .filter((option) => !isNeverSchema(option))
+        .map((option) => stripUnsupportedKeywords(option, context)),
+    };
+  }
+
+  return stripUnsupportedKeywords(schema, context);
+}
+
+function stripUnsupportedKeywords(schema: ZodJsonSchema, context: CompatibilityContext): ZodJsonSchema {
+  const hasRedundantSafeIntegerBounds = isRedundantSafeIntegerBounds(schema);
+  const stripped: ZodJsonSchema = Object.fromEntries(
+    Object.entries(schema).flatMap(([key, value]) => {
+      switch (key) {
+        case "minimum":
+        case "maximum":
+          return context.features.numbers.bounds === "instructions" ? [] : [[key, value]];
+        case "multipleOf":
+          return context.features.numbers.multipleOf === "instructions" ? [] : [[key, value]];
+        case "minLength":
+        case "maxLength":
+          return context.features.strings.length === "instructions" ? [] : [[key, value]];
+        case "maxItems":
+          return context.features.arrays.length === "native" ? [[key, value]] : [];
+        case "minItems":
+          if (context.features.arrays.length === "native") return [[key, value]];
+          if (context.features.arrays.length === "min1-only" && value === 1) return [[key, value]];
+          return [];
+        case "items":
+          if (isJsonSchema(value)) return [[key, stripUnsupportedKeywords(value, context)]];
+          if (Array.isArray(value)) {
+            return [[key, value.map((item) => isJsonSchema(item) ? stripUnsupportedKeywords(item, context) : item)]];
+          }
+          return [[key, value]];
+        case "anyOf":
+          return [[
+            key,
+            Array.isArray(value)
+              ? value.map((option) => isJsonSchema(option) ? stripUnsupportedKeywords(option, context) : option)
+              : value,
+          ]];
+        case "prefixItems":
+          return [[
+            key,
+            Array.isArray(value)
+              ? value.map((option) => isJsonSchema(option) ? stripUnsupportedKeywords(option, context) : option)
+              : value,
+          ]];
+        case "properties":
+          return [[
+            key,
+            isPlainObject(value)
+              ? Object.fromEntries(
+                Object.entries(value).map(([propertyKey, propertyValue]) => [
+                  propertyKey,
+                  isJsonSchema(propertyValue) ? stripUnsupportedKeywords(propertyValue, context) : propertyValue,
+                ]),
+              )
+              : value,
+          ]];
+        case "additionalProperties":
+        case "propertyNames":
+          return [[key, isJsonSchema(value) ? stripUnsupportedKeywords(value, context) : value]];
+        default:
+          return [[key, value]];
+      }
+    }),
+  );
+
+  const normalized = hasRedundantSafeIntegerBounds ? omitSchemaKeywords(stripped, ["minimum", "maximum"]) : stripped;
+
+  if (getPrimaryType(schema) === "integer" && context.features.numbers.integerType === "number") {
+    return { ...normalized, type: "number" };
+  }
+
+  return normalized;
+}
+
+function createCompatibilityContext(features: SchemaCompatibilityFeatures): CompatibilityContext {
+  return {
+    constraints: [],
+    usedRecord: false,
+    usedDynamicRecordFallback: false,
+    usedTupleSurrogate: false,
+    features,
+  };
+}
+
+function shouldWrapTopLevelObject(requireTopLevelObject: boolean | undefined, schema: ZodJsonSchema): boolean {
+  return Boolean(requireTopLevelObject) && !isObjectLikeSchema(schema);
+}
+
+function getArrayKeywordsToOmit(
+  length: SchemaCompatibilityFeatures["arrays"]["length"],
+  minItems: number | undefined,
+): string[] {
+  if (length === "instructions") return ["minItems", "maxItems"];
+  if (length === "min1-only") return minItems === 1 ? ["maxItems"] : ["minItems", "maxItems"];
+  return [];
+}
+
+function getNumberKeywordsToOmit(options: {
+  bounds: SchemaCompatibilityFeatures["numbers"]["bounds"];
+  multipleOf: SchemaCompatibilityFeatures["numbers"]["multipleOf"];
+  hasRedundantSafeIntegerBounds: boolean;
+}): string[] {
+  const keys: string[] = [];
+  if (options.bounds === "instructions" || options.hasRedundantSafeIntegerBounds) {
+    keys.push("minimum", "maximum");
+  }
+  if (options.multipleOf === "instructions") {
+    keys.push("multipleOf");
+  }
+  return keys;
+}
+
+function getInstructionGlossary(context: CompatibilityContext): string[] {
+  const glossary: string[] = [];
+
+  if (context.usedTupleSurrogate) {
+    glossary.push(
+      "Tuple - An ordered fixed-length sequence. In the compatible schema it is represented as an object with keys `item0`, `item1`, etc. If the tuple has a rest element, it appears under `rest`.",
+    );
+  }
+
+  if (context.usedDynamicRecordFallback) {
+    glossary.push(
+      "Record - A key-value map. Finite-key records are represented as explicit objects. Dynamic records are represented as arrays of `{ key, value }` objects because compatibility mode avoids `additionalProperties` schemas.",
+    );
+  } else if (context.usedRecord && context.features.records.finite === "explicit-object") {
+    glossary.push(
+      "Record - A key-value map. Finite-key records are represented as explicit objects in the compatible schema.",
+    );
+  }
+
+  return glossary;
+}
+
+function getInstructionEnvelope(kind: "output" | "tool"): { tag: string; intro: string } {
+  if (kind === "output") {
+    return {
+      tag: "output_requirements",
+      intro:
+        "Your final output must conform to the provided JSON Schema, and additionally satisfy the following requirements:",
+    };
+  }
+
+  return {
+    tag: "input_requirements",
+    intro:
+      "Tool arguments must conform to the provided JSON Schema, and additionally satisfy the following requirements:",
+  };
+}
+
+function omitSchemaKeywords(schema: ZodJsonSchema, keys: string[]): ZodJsonSchema {
+  if (keys.length === 0) return { ...schema };
+  const keySet = new Set(keys);
+  return Object.fromEntries(Object.entries(schema).filter(([key]) => !keySet.has(key)));
+}
+
+function identity(value: unknown): unknown {
+  return value;
+}
+
+function identityNode(schema: ZodJsonSchema, context: CompatibilityContext): CompatibilityNode {
+  return {
+    jsonSchema: stripUnsupportedKeywords(schema, context),
+    toProvider: identity,
+    fromProvider: identity,
+  };
+}
+
+function getPrimaryType(schema: ZodJsonSchema): string | undefined {
+  return Array.isArray(schema.type) ? schema.type[0] : schema.type;
+}
+
+function isJsonSchema(value: unknown): value is ZodJsonSchema {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isObjectLikeSchema(schema: ZodJsonSchema): schema is JSONSchema.ObjectSchema {
+  return getPrimaryType(schema) === "object" || !!schema.properties;
+}
+
+function isRecordSchema(schema: ZodJsonSchema): boolean {
+  return getPrimaryType(schema) === "object" && isJsonSchema(schema.additionalProperties);
+}
+
+function isRedundantSafeIntegerBounds(schema: ZodJsonSchema): boolean {
+  return getPrimaryType(schema) === "integer" &&
+    schema.minimum === Number.MIN_SAFE_INTEGER &&
+    schema.maximum === Number.MAX_SAFE_INTEGER;
+}
+
+function isNeverSchema(schema: ZodJsonSchema): boolean {
+  return isJsonSchema(schema.not) && Object.keys(schema.not).length === 0;
+}
+
+function getFinitePropertyNames(schema: ZodJsonSchemaInput | undefined): { keys: string[]; partial: boolean } | null {
+  if (!isJsonSchema(schema)) return null;
+
+  if (
+    Array.isArray(schema.enum) && schema.enum.every((value) => typeof value === "string" || typeof value === "number")
+  ) {
+    return { keys: schema.enum.map(String), partial: false };
+  }
+
+  if ((typeof schema.const === "string" || typeof schema.const === "number")) {
+    return { keys: [String(schema.const)], partial: false };
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    let partial = false;
+    const keys: string[] = [];
+    for (const option of schema.anyOf) {
+      if (isNeverSchema(option)) {
+        partial = true;
+        continue;
+      }
+      const nested = getFinitePropertyNames(option);
+      if (!nested || nested.partial) return null;
+      keys.push(...nested.keys);
+    }
+    return keys.length > 0 ? { keys: [...new Set(keys)], partial } : null;
+  }
+
+  return null;
+}
+
+function schemaTypeToString(schema: ZodJsonSchemaInput | ZodJsonSchemaInput[] | undefined): string {
+  if (schema === false) return "never";
+  if (schema === true || schema === undefined) return "unknown";
+  if (Array.isArray(schema)) {
+    return schema.map((item) => schemaTypeToString(item)).join(" | ");
+  }
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+    return schema.anyOf.map((option) => schemaTypeToString(option)).join(" | ");
+  }
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum.map((value) => JSON.stringify(value)).join(" | ");
+  }
+  if (schema.const !== undefined) return JSON.stringify(schema.const);
+  if (Array.isArray(schema.prefixItems)) {
+    const items = schema.prefixItems.map((item) => schemaTypeToString(item));
+    if (schema.items) return `[${items.join(", ")}, ...${schemaTypeToString(schema.items)}[]]`;
+    return `[${items.join(", ")}]`;
+  }
+
+  const type = getPrimaryType(schema);
+  switch (type) {
+    case "object": {
+      if (isJsonSchema(schema.additionalProperties)) {
+        return `Record<${schemaTypeToString(schema.propertyNames)}, ${
+          schemaTypeToString(schema.additionalProperties)
+        }>`;
+      }
+      return "object";
+    }
+    case "array":
+      return `${schemaTypeToString(schema.items)}[]`;
+    case "integer":
+      return "integer";
+    case "number":
+    case "string":
+    case "boolean":
+    case "null":
+      return type;
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * When we rebuild a schema node from scratch, keep only human-facing annotations.
+ * Spreading the full schema would also copy structural keywords that are being intentionally replaced.
+ */
+function preserveSchemaMetadata(schema: ZodJsonSchema): ZodJsonSchema {
+  const metadata: ZodJsonSchema = {};
+  if (schema.description !== undefined) metadata.description = schema.description;
+  if (schema.title !== undefined) metadata.title = schema.title;
+  if (schema.default !== undefined) metadata.default = schema.default;
+  return metadata;
+}
+
+function matchesSchema(value: unknown, schema: ZodJsonSchemaInput | undefined, context: CompatibilityContext): boolean {
+  if (schema === false) return false;
+  if (schema === true || schema === undefined) return true;
+
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+    return schema.anyOf.some((option) => matchesSchema(value, option, context));
+  }
+
+  if (Array.isArray(schema.enum)) return schema.enum.some((candidate) => candidate === value);
+  if (schema.const !== undefined) return schema.const === value;
+
+  if (Array.isArray(schema.prefixItems)) {
+    return context.features.tuples.strategy === "native" ? Array.isArray(value) : isPlainObject(value);
+  }
+
+  switch (getPrimaryType(schema)) {
+    case "object":
+      return isPlainObject(value);
+    case "array":
+      return Array.isArray(value);
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "number":
+      return typeof value === "number";
+    case "string":
+      return typeof value === "string";
+    case "boolean":
+      return typeof value === "boolean";
+    case "null":
+      return value === null;
+    default:
+      return true;
+  }
+}
+
+function coerceKeyFromObject(
+  key: string,
+  propertyNames: ZodJsonSchemaInput | undefined,
+  context: CompatibilityContext,
+): JsonValue {
+  if (!isJsonSchema(propertyNames)) return key;
+
+  if (Array.isArray(propertyNames.anyOf)) {
+    for (const option of propertyNames.anyOf) {
+      if (isNeverSchema(option)) continue;
+      const coerced = coerceKeyFromObject(key, option, context);
+      if (matchesSchema(coerced, option, context)) return coerced;
+    }
+    return key;
+  }
+
+  if (getPrimaryType(propertyNames) === "number" || getPrimaryType(propertyNames) === "integer") {
+    const numeric = Number(key);
+    return Number.isNaN(numeric) ? key : numeric;
+  }
+  if ((typeof propertyNames.const === "string" || typeof propertyNames.const === "number")) {
+    return propertyNames.const;
+  }
+  if (Array.isArray(propertyNames.enum)) {
+    const match = propertyNames.enum.find((candidate) => String(candidate) === key);
+    return match ?? key;
+  }
+  return key;
+}

--- a/src/adapters/shared/tools.ts
+++ b/src/adapters/shared/tools.ts
@@ -1,24 +1,42 @@
-import type z from "zod";
+interface SharedSchemaCompatibility {
+  toProvider(value: unknown): unknown;
+  fromProvider(value: unknown): unknown;
+}
 
 export interface SharedToolShape {
   wrapperObject: boolean;
   isVoid: boolean;
-}
-
-export interface SharedToolSchemaInfo extends SharedToolShape {
-  schema: z.ZodType;
-  jsonSchema: Record<string, unknown>;
+  compatibility?: SharedSchemaCompatibility;
 }
 
 export function serializeWrappedToolArguments(content: string | undefined, tool: SharedToolShape | undefined): string {
   if (tool?.isVoid) return "{}";
   if (!content) return "{}";
+
+  if (tool?.compatibility) {
+    try {
+      return JSON.stringify(tool.compatibility.toProvider(JSON.parse(content)));
+    } catch {
+      return content;
+    }
+  }
+
   if (!tool?.wrapperObject) return content;
   return `{"content":${content}}`;
 }
 
 export function restoreWrappedToolArguments(content: string, tool: SharedToolShape | undefined): string | undefined {
   if (tool?.isVoid) return undefined;
+
+  if (tool?.compatibility) {
+    try {
+      const restored = tool.compatibility.fromProvider(JSON.parse(content));
+      return restored === undefined ? undefined : JSON.stringify(restored);
+    } catch {
+      return content;
+    }
+  }
+
   if (!tool?.wrapperObject) return content;
 
   try {

--- a/tests/adapters/anthropic.test.ts
+++ b/tests/adapters/anthropic.test.ts
@@ -12,6 +12,7 @@ import {
   runAgentToolStreamingTest,
   runBackAndForthCalculatorConversationTest,
   runStructuredOutputStreamingTest,
+  runStructuredToolParameterStreamingTest,
 } from "./shared.ts";
 
 const HAS_ANTHROPIC_KEY = Boolean(Deno.env.get("ANTHROPIC_API_KEY"));
@@ -128,6 +129,18 @@ Deno.test({
 });
 
 Deno.test({
+  name: "AnthropicModel executes structured tool parameters (claude-sonnet-4-6, adaptive mode)",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn(t) {
+    await runStructuredToolParameterStreamingTest(t, {
+      model: new AnthropicModel({ model: "claude-sonnet-4-6", effort: "low" }),
+    });
+  },
+});
+
+Deno.test({
   name: "AnthropicModel streams native structured output (claude-sonnet-4-6)",
   ignore: !HAS_ANTHROPIC_KEY,
   sanitizeOps: false,
@@ -182,7 +195,7 @@ Deno.test("dynamic records and tuples round-trip through Anthropic compatibility
     },
   };
 
-  const anthropic = compatibility.toAnthropic(original);
+  const anthropic = compatibility.toProvider(original);
   assertEquals(anthropic, {
     tone: { item0: "formal", item1: "warm" },
     metadata: [
@@ -191,7 +204,7 @@ Deno.test("dynamic records and tuples round-trip through Anthropic compatibility
     ],
   });
 
-  assertEquals(compatibility.fromAnthropic(anthropic), original);
+  assertEquals(compatibility.fromProvider(anthropic), original);
   assert(compatibility.instructions.includes("Tuple"));
   assert(compatibility.instructions.includes("Record"));
 });
@@ -207,11 +220,11 @@ Deno.test("finite-key records stay object-shaped", () => {
   const anthropicJsonSchema = compatibility.jsonSchema;
   assertEquals(anthropicJsonSchema.type, "object");
   assertEquals(Array.isArray(anthropicJsonSchema.required), true);
-  assertEquals(compatibility.toAnthropic({ id: "1", name: "Bingus" }), {
+  assertEquals(compatibility.toProvider({ id: "1", name: "Bingus" }), {
     id: "1",
     name: "Bingus",
   });
-  assertEquals(compatibility.fromAnthropic({ id: "1", name: "Bingus" }), {
+  assertEquals(compatibility.fromProvider({ id: "1", name: "Bingus" }), {
     id: "1",
     name: "Bingus",
   });
@@ -226,8 +239,8 @@ Deno.test("tool schemas can be wrapped to satisfy Anthropic top-level object req
     rootPath: "input",
   });
 
-  assertEquals(compatibility.toAnthropic("cats"), { content: "cats" });
-  assertEquals(compatibility.fromAnthropic({ content: "cats" }), "cats");
+  assertEquals(compatibility.toProvider("cats"), { content: "cats" });
+  assertEquals(compatibility.fromProvider({ content: "cats" }), "cats");
 
   const anthropicJsonSchema = compatibility.jsonSchema;
   assertEquals(anthropicJsonSchema.type, "object");

--- a/tests/adapters/gemini.test.ts
+++ b/tests/adapters/gemini.test.ts
@@ -8,6 +8,7 @@ import {
   runAgentToolStreamingTest,
   runBackAndForthCalculatorConversationTest,
   runStructuredOutputStreamingTest,
+  runStructuredToolParameterStreamingTest,
 } from "./shared.ts";
 
 const HAS_GEMINI_KEY = Boolean(Deno.env.get("GEMINI_API_KEY"));
@@ -208,6 +209,18 @@ Deno.test({
   async fn(t) {
     await runAgentToolStreamingTest(t, {
       model: new GeminiModel({ model: "gemini-2.0-flash-lite" }),
+    });
+  },
+});
+
+Deno.test({
+  name: "GeminiModel executes structured tool parameters (gemini-2.5-flash, legacy thinking-budget)",
+  ignore: !HAS_GEMINI_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn(t) {
+    await runStructuredToolParameterStreamingTest(t, {
+      model: new GeminiModel({ model: "gemini-2.5-flash", thinkingLevel: "low" }),
     });
   },
 });

--- a/tests/adapters/open-responses.test.ts
+++ b/tests/adapters/open-responses.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import type OpenAI from "openai";
 import z from "zod";
 import { OpenResponsesAdapter } from "../../src/adapters/open_responses/adapter.ts";
@@ -159,6 +159,231 @@ Deno.test("Open Responses retry feedback is replayed as a user message", async (
   ]);
 });
 
+Deno.test("Open Responses uses reversible OpenAI compatibility for tuple and record tool schemas", () => {
+  const tupleTool = new Tool({
+    name: "Tuple Tool",
+    description: "Uses nested tuple and record input",
+    parameters: z.object({
+      header: z.object({
+        tags: z.tuple([z.string(), z.number()]),
+      }).strict(),
+      metadata: z.record(z.string(), z.object({ score: z.number() }).strict()),
+    }).strict(),
+    execute: () => "unused",
+  });
+
+  const [normalizedTool] = normalizeOpenResponsesTools([tupleTool]);
+  const parameters = normalizedTool?.openResponses.parameters as {
+    properties?: Record<string, unknown>;
+  };
+  const header = parameters.properties?.header as { properties?: Record<string, unknown> } | undefined;
+  const metadata = parameters.properties?.metadata as { items?: Record<string, unknown> } | undefined;
+  const tags = header?.properties?.tags as {
+    type?: unknown;
+    properties?: Record<string, unknown>;
+    required?: unknown;
+    prefixItems?: unknown;
+  } | undefined;
+
+  assertEquals(
+    normalizedTool?.compatibility?.toProvider({
+      header: { tags: ["cats", 2] },
+      metadata: { alpha: { score: 0.5 } },
+    }),
+    {
+      header: { tags: { item0: "cats", item1: 2 } },
+      metadata: [{ key: "alpha", value: { score: 0.5 } }],
+    },
+  );
+  assertEquals(
+    normalizedTool?.compatibility?.fromProvider({
+      header: { tags: { item0: "cats", item1: 2 } },
+      metadata: [{ key: "alpha", value: { score: 0.5 } }],
+    }),
+    {
+      header: { tags: ["cats", 2] },
+      metadata: { alpha: { score: 0.5 } },
+    },
+  );
+
+  assertEquals(tags?.prefixItems, undefined);
+  assertEquals(tags?.type, "object");
+  assertEquals(tags?.properties, {
+    item0: { type: "string" },
+    item1: { type: "number" },
+  });
+  assertEquals(tags?.required, ["item0", "item1"]);
+  assertEquals(metadata?.items, {
+    type: "object",
+    properties: {
+      key: { type: "string" },
+      value: {
+        type: "object",
+        properties: { score: { type: "number" } },
+        required: ["score"],
+        additionalProperties: false,
+      },
+    },
+    required: ["key", "value"],
+    additionalProperties: false,
+  });
+  assert(normalizedTool?.openResponses.description?.includes("<input_requirements>"));
+});
+
+Deno.test("Open Responses restores structured output from OpenAI-compatible surrogate shapes", async () => {
+  let capturedRequest: unknown;
+
+  const adapter = new OpenResponsesAdapter({
+    model: "test-model",
+    name: "Test Provider",
+    client: createMockClient(
+      [
+        {
+          type: "response.output_text.delta",
+          sequence_number: 1,
+          output_index: 0,
+          content_index: 0,
+          item_id: "msg_1",
+          delta: '{"tags":{"item0":"red","item1":2},"metadata":[{"key":"alpha","value":"1"}]}',
+          logprobs: [],
+        },
+      ],
+      { usage: { input_tokens: 3, output_tokens: 2 } },
+      (request) => {
+        capturedRequest = request;
+      },
+    ),
+  });
+
+  const stream = adapter.stream({
+    history: [],
+    instructions: "Be useful",
+    tools: [],
+    signal: AbortSignal.abort(),
+    output: z.object({
+      tags: z.tuple([z.string(), z.number()]),
+      metadata: z.record(z.string(), z.string()),
+    }),
+  });
+
+  const items = [];
+  while (true) {
+    const next = await stream.next();
+    if (next.done) break;
+    items.push(next.value);
+  }
+
+  assertEquals(items, [{
+    type: "delta_output_text",
+    index: 0,
+    delta: '{"tags":["red",2],"metadata":{"alpha":"1"}}',
+  }]);
+
+  assert((capturedRequest as { instructions: string }).instructions.includes("<output_requirements>"));
+});
+
+Deno.test("Open Responses stream unwraps primitive tool arguments when the done event omits the tool name", async () => {
+  const searchTool = new Tool({
+    name: "Search",
+    description: "Search for documents",
+    parameters: z.string(),
+    execute: () => "unused",
+  });
+
+  const adapter = new OpenResponsesAdapter({
+    model: "test-model",
+    name: "Test Provider",
+    client: createMockClient([
+      {
+        type: "response.output_item.added",
+        sequence_number: 1,
+        output_index: 0,
+        item: {
+          id: "fc_1",
+          type: "function_call",
+          status: "in_progress",
+          call_id: "call_1",
+          name: "search",
+          arguments: "",
+        },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        sequence_number: 2,
+        output_index: 0,
+        item_id: "fc_1",
+        arguments: '{"content":"cats"}',
+      },
+    ], {
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }),
+  });
+
+  const stream = adapter.stream({
+    history: [],
+    instructions: "Be useful",
+    tools: [searchTool],
+    signal: AbortSignal.abort(),
+  });
+
+  const items = [];
+  while (true) {
+    const next = await stream.next();
+    if (next.done) break;
+    items.push(next.value);
+  }
+
+  assertEquals(items, [
+    { type: "tool_use_start", tool_use_id: "call_1", kind: "Search", index: 0 },
+    { type: "tool_use", tool_use_id: "call_1", kind: "Search", content: '"cats"', index: 0 },
+  ]);
+});
+
+Deno.test("Open Responses synthesizes tool_use_start when arguments.done arrives without output_item.added", async () => {
+  const searchTool = new Tool({
+    name: "Search",
+    description: "Search for documents",
+    parameters: z.string(),
+    execute: () => "unused",
+  });
+
+  const adapter = new OpenResponsesAdapter({
+    model: "test-model",
+    name: "Test Provider",
+    client: createMockClient([
+      {
+        type: "response.function_call_arguments.done",
+        sequence_number: 1,
+        output_index: 0,
+        item_id: "fc_1",
+        name: "search",
+        arguments: '{"content":"cats"}',
+      },
+    ], {
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }),
+  });
+
+  const stream = adapter.stream({
+    history: [],
+    instructions: "Be useful",
+    tools: [searchTool],
+    signal: AbortSignal.abort(),
+  });
+
+  const items = [];
+  while (true) {
+    const next = await stream.next();
+    if (next.done) break;
+    items.push(next.value);
+  }
+
+  assertEquals(items, [
+    { type: "tool_use_start", tool_use_id: "fc_1", kind: "Search", index: 0 },
+    { type: "tool_use", tool_use_id: "fc_1", kind: "Search", content: '"cats"', index: 0 },
+  ]);
+});
+
 Deno.test("Open Responses stream maps text, reasoning, refusal, and function calls", async () => {
   let capturedRequest: unknown;
 
@@ -289,10 +514,12 @@ Deno.test("Open Responses stream maps text, reasoning, refusal, and function cal
       description: "Search for documents",
       strict: false,
       parameters: {
-        $schema: "https://json-schema.org/draft/2020-12/schema",
         type: "object",
         properties: {
-          content: { type: "string" },
+          content: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
+            type: "string",
+          },
         },
         required: ["content"],
         additionalProperties: false,
@@ -304,7 +531,6 @@ Deno.test("Open Responses stream maps text, reasoning, refusal, and function cal
         name: "output",
         strict: true,
         schema: {
-          $schema: "https://json-schema.org/draft/2020-12/schema",
           type: "object",
           properties: {
             answer: { type: "string" },
@@ -321,7 +547,7 @@ Deno.test("Open Responses stream maps text, reasoning, refusal, and function cal
 
 Deno.test("OpenAIModel defaults effort for reasoning models", () => {
   const model = new OpenAIModel({
-    model: "gpt-5",
+    model: "gpt-5.4",
     apiKey: "test-key",
   });
 
@@ -339,7 +565,7 @@ Deno.test("OpenAIModel omits reasoning for non-reasoning models", () => {
 
 Deno.test("OpenAIModel stores configured service tier", () => {
   const model = new OpenAIModel({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-nano",
     apiKey: "test-key",
     serviceTier: "flex",
   });
@@ -369,7 +595,7 @@ Deno.test("Open Responses respects explicitly configured supported mime types", 
 
 Deno.test("OpenAIModel infers supported mime types from model modalities", async () => {
   const multimodalModel = new OpenAIModel({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-nano",
     apiKey: "test-key",
   });
   const textOnlyModel = new OpenAIModel({

--- a/tests/adapters/openai-completions.test.ts
+++ b/tests/adapters/openai-completions.test.ts
@@ -1,9 +1,9 @@
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import type OpenAI from "openai";
-import { assertEquals, assertThrows } from "@std/assert";
 import z from "zod";
-import { RETRY_RESUMABILITY_PROMPT } from "../../src/constants.ts";
 import { OpenAICompletionsAdapter } from "../../src/adapters/openai_completions/adapter.ts";
 import { normalizeOpenAICompletionsTools } from "../../src/adapters/openai_completions/tools.ts";
+import { RETRY_RESUMABILITY_PROMPT } from "../../src/constants.ts";
 import { Tool } from "../../src/tool.ts";
 
 function createMockClient(
@@ -159,6 +159,131 @@ Deno.test("OpenAI Completions retry feedback is replayed as user content and res
   ]);
 });
 
+Deno.test("OpenAI Completions uses reversible OpenAI compatibility for tuple and record tool schemas", () => {
+  const tupleTool = new Tool({
+    name: "Tuple Tool",
+    description: "Uses nested tuple and record input",
+    parameters: z.object({
+      header: z.object({
+        tags: z.tuple([z.string(), z.number()]),
+      }).strict(),
+      metadata: z.record(z.string(), z.object({ score: z.number() }).strict()),
+    }).strict(),
+    execute: () => "unused",
+  });
+
+  const [normalizedTool] = normalizeOpenAICompletionsTools([tupleTool]);
+  const parameters = normalizedTool?.openAI.function.parameters as {
+    properties?: Record<string, unknown>;
+  };
+  const header = parameters.properties?.header as { properties?: Record<string, unknown> } | undefined;
+  const metadata = parameters.properties?.metadata as { items?: Record<string, unknown> } | undefined;
+  const tags = header?.properties?.tags as {
+    type?: unknown;
+    properties?: Record<string, unknown>;
+    required?: unknown;
+    prefixItems?: unknown;
+  } | undefined;
+
+  assertEquals(
+    normalizedTool?.compatibility?.toProvider({
+      header: { tags: ["cats", 2] },
+      metadata: { alpha: { score: 0.5 } },
+    }),
+    {
+      header: { tags: { item0: "cats", item1: 2 } },
+      metadata: [{ key: "alpha", value: { score: 0.5 } }],
+    },
+  );
+  assertEquals(
+    normalizedTool?.compatibility?.fromProvider({
+      header: { tags: { item0: "cats", item1: 2 } },
+      metadata: [{ key: "alpha", value: { score: 0.5 } }],
+    }),
+    {
+      header: { tags: ["cats", 2] },
+      metadata: { alpha: { score: 0.5 } },
+    },
+  );
+
+  assertEquals(tags?.prefixItems, undefined);
+  assertEquals(tags?.type, "object");
+  assertEquals(tags?.properties, {
+    item0: { type: "string" },
+    item1: { type: "number" },
+  });
+  assertEquals(tags?.required, ["item0", "item1"]);
+  assertEquals(metadata?.items, {
+    type: "object",
+    properties: {
+      key: { type: "string" },
+      value: {
+        type: "object",
+        properties: { score: { type: "number" } },
+        required: ["score"],
+        additionalProperties: false,
+      },
+    },
+    required: ["key", "value"],
+    additionalProperties: false,
+  });
+  assert(normalizedTool?.openAI.function.description?.includes("<input_requirements>"));
+});
+
+Deno.test("OpenAI Completions restores structured output from OpenAI-compatible surrogate shapes", async () => {
+  let capturedRequest: unknown;
+
+  const adapter = new OpenAICompletionsAdapter({
+    model: "test-model",
+    name: "Test Provider",
+    client: createMockClient(
+      [
+        {
+          choices: [{
+            delta: {
+              content: '{"tags":{"item0":"red","item1":2},"metadata":[{"key":"alpha","value":"1"}]}',
+            },
+          }],
+        },
+      ],
+      { prompt_tokens: 3, completion_tokens: 2 },
+      (request) => {
+        capturedRequest = request;
+      },
+    ),
+  });
+
+  const stream = adapter.stream({
+    history: [],
+    instructions: "Be useful",
+    tools: [],
+    signal: AbortSignal.abort(),
+    output: z.object({
+      tags: z.tuple([z.string(), z.number()]),
+      metadata: z.record(z.string(), z.string()),
+    }),
+  });
+
+  const items = [];
+  while (true) {
+    const next = await stream.next();
+    if (next.done) break;
+    items.push(next.value);
+  }
+
+  assertEquals(items, [{
+    type: "delta_output_text",
+    index: 0,
+    delta: '{"tags":["red",2],"metadata":{"alpha":"1"}}',
+  }]);
+
+  assert(
+    ((capturedRequest as { messages: Array<{ content: string }> }).messages[0]?.content).includes(
+      "<output_requirements>",
+    ),
+  );
+});
+
 Deno.test("OpenAI Completions stream maps text, reasoning, and tool calls", async () => {
   let capturedRequest: unknown;
 
@@ -269,10 +394,12 @@ Deno.test("OpenAI Completions stream maps text, reasoning, and tool calls", asyn
         description: "Search for documents",
         strict: true,
         parameters: {
-          $schema: "https://json-schema.org/draft/2020-12/schema",
           type: "object",
           properties: {
-            content: { type: "string" },
+            content: {
+              $schema: "https://json-schema.org/draft/2020-12/schema",
+              type: "string",
+            },
           },
           required: ["content"],
           additionalProperties: false,
@@ -285,7 +412,6 @@ Deno.test("OpenAI Completions stream maps text, reasoning, and tool calls", asyn
         name: "output",
         strict: true,
         schema: {
-          $schema: "https://json-schema.org/draft/2020-12/schema",
           type: "object",
           properties: {
             answer: { type: "string" },

--- a/tests/adapters/openai.test.ts
+++ b/tests/adapters/openai.test.ts
@@ -7,6 +7,7 @@ import {
   runAgentToolStreamingTest,
   runBackAndForthCalculatorConversationTest,
   runStructuredOutputStreamingTest,
+  runStructuredToolParameterStreamingTest,
 } from "./shared.ts";
 
 const HAS_OPENAI_KEY = Boolean(Deno.env.get("OPENAI_API_KEY"));
@@ -64,13 +65,13 @@ Deno.test({
 });
 
 Deno.test({
-  name: "OpenAIModel streams tools and results (gpt-4.1-mini, non-reasoning)",
+  name: "OpenAIModel executes structured tool parameters (gpt-5.4-mini, non-reasoning)",
   ignore: !HAS_OPENAI_KEY,
   sanitizeOps: false,
   sanitizeResources: false,
   async fn(t) {
-    await runAgentToolStreamingTest(t, {
-      model: new OpenAIModel({ model: "gpt-4.1-mini" }),
+    await runStructuredToolParameterStreamingTest(t, {
+      model: new OpenAIModel({ model: "gpt-5.4-mini" }),
     });
   },
 });
@@ -83,18 +84,6 @@ Deno.test({
   async fn(t) {
     await runStructuredOutputStreamingTest(t, {
       model: new OpenAIModel({ model: "gpt-5.4-mini", effort: "low" }),
-    });
-  },
-});
-
-Deno.test({
-  name: "OpenAIModel streams structured output (gpt-4.1-mini, non-reasoning)",
-  ignore: !HAS_OPENAI_KEY,
-  sanitizeOps: false,
-  sanitizeResources: false,
-  async fn(t) {
-    await runStructuredOutputStreamingTest(t, {
-      model: new OpenAIModel({ model: "gpt-4.1-mini" }),
     });
   },
 });

--- a/tests/adapters/openrouter.test.ts
+++ b/tests/adapters/openrouter.test.ts
@@ -7,6 +7,7 @@ import {
   runAgentToolStreamingTest,
   runBackAndForthCalculatorConversationTest,
   runStructuredOutputStreamingTest,
+  runStructuredToolParameterStreamingTest,
 } from "./shared.ts";
 
 const HAS_OPENROUTER_KEY = Boolean(Deno.env.get("OPENROUTER_API_KEY"));
@@ -59,6 +60,18 @@ Deno.test({
   async fn(t) {
     await runAgentToolStreamingTest(t, {
       model: new OpenRouterModel({ model: "anthropic/claude-sonnet-4.5", effort: "medium" }),
+    });
+  },
+});
+
+Deno.test({
+  name: "OpenRouterModel executes structured tool parameters (openai/gpt-5-mini)",
+  ignore: !HAS_OPENROUTER_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn(t) {
+    await runStructuredToolParameterStreamingTest(t, {
+      model: new OpenRouterModel({ model: "openai/gpt-5-mini", effort: "medium" }),
     });
   },
 });

--- a/tests/adapters/shared.ts
+++ b/tests/adapters/shared.ts
@@ -69,6 +69,222 @@ export function createStructuredOutputFixtures() {
   };
 }
 
+interface StructuredToolSimpleObjectInput {
+  label: string;
+  count: number;
+}
+
+interface StructuredToolMetadataValue {
+  state: "ready";
+  score: number;
+}
+
+interface StructuredToolNestedInput {
+  header: {
+    id: string;
+    priority: number;
+    tags: [string, string, string];
+  };
+  windows: [
+    { day: "mon"; range: [number, number] },
+    { day: "fri"; range: [number, number] },
+  ];
+  metadata: Record<string, StructuredToolMetadataValue>;
+}
+
+function createStructuredToolParameterFixtures() {
+  const expected = {
+    plainString: "lattice",
+    constrainedString: "orbitals",
+    decimalNumber: 12.5,
+    constrainedInteger: 17,
+    simpleObject: {
+      label: "otter",
+      count: 2,
+    } satisfies StructuredToolSimpleObjectInput,
+    nestedObject: {
+      header: {
+        id: "case_alpha",
+        priority: 3,
+        tags: ["red", "blue", "green"],
+      },
+      windows: [
+        { day: "mon", range: [9, 11] },
+        { day: "fri", range: [14, 16] },
+      ],
+      metadata: {
+        alpha: { state: "ready", score: 0.5 },
+        beta: { state: "ready", score: 0.5 },
+      },
+    } satisfies StructuredToolNestedInput,
+  };
+
+  const state = {
+    plainStrings: [] as string[],
+    constrainedStrings: [] as string[],
+    decimalNumbers: [] as number[],
+    constrainedIntegers: [] as number[],
+    voidCalls: 0,
+    simpleObjects: [] as StructuredToolSimpleObjectInput[],
+    nestedObjects: [] as StructuredToolNestedInput[],
+  };
+
+  const plainStringTool = new Tool({
+    name: "plain_string_input",
+    description: `Call this tool exactly once with the bare string ${JSON.stringify(expected.plainString)}.`,
+    parameters: z.string(),
+    execute: (input) => {
+      state.plainStrings.push(input);
+      return "ok:plain-string";
+    },
+  });
+
+  const constrainedStringTool = new Tool({
+    name: "constrained_string_input",
+    description: `Call this tool exactly once with the bare lowercase string ${
+      JSON.stringify(expected.constrainedString)
+    }.`,
+    parameters: z.string().min(8).max(9).regex(/^[a-z]+$/),
+    execute: (input) => {
+      state.constrainedStrings.push(input);
+      return "ok:constrained-string";
+    },
+  });
+
+  const decimalNumberTool = new Tool({
+    name: "decimal_number_input",
+    description: `Call this tool exactly once with the bare number ${expected.decimalNumber}.`,
+    parameters: z.number(),
+    execute: (input) => {
+      state.decimalNumbers.push(input);
+      return "ok:decimal-number";
+    },
+  });
+
+  const constrainedIntegerTool = new Tool({
+    name: "constrained_integer_input",
+    description: `Call this tool exactly once with the bare integer ${expected.constrainedInteger}.`,
+    parameters: z.int().min(17).max(17),
+    execute: (input) => {
+      state.constrainedIntegers.push(input);
+      return "ok:constrained-integer";
+    },
+  });
+
+  const voidTool = new Tool({
+    name: "void_input",
+    description: "Call this tool exactly once with no parameters.",
+    parameters: z.void(),
+    execute: () => {
+      state.voidCalls += 1;
+      return "ok:void";
+    },
+  });
+
+  const simpleObjectTool = new Tool({
+    name: "simple_object_input",
+    description: `Call this tool exactly once with ${JSON.stringify(expected.simpleObject)}.`,
+    parameters: z.object({
+      label: z.string().min(5).max(5),
+      count: z.int().min(2).max(2),
+    }).strict(),
+    execute: (input) => {
+      state.simpleObjects.push(input);
+      return "ok:simple-object";
+    },
+  });
+
+  const nestedObjectTool = new Tool({
+    name: "nested_object_input",
+    description: `Call this tool exactly once with ${JSON.stringify(expected.nestedObject)}.`,
+    parameters: z.object({
+      header: z.object({
+        id: z.string().min(10).max(10).regex(/^case_[a-z]{5}$/),
+        priority: z.int().min(3).max(3),
+        tags: z.tuple([
+          z.string().min(3).max(3),
+          z.string().min(4).max(4),
+          z.string().min(5).max(5),
+        ]),
+      }).strict(),
+      windows: z.tuple([
+        z.object({
+          day: z.literal("mon"),
+          range: z.tuple([z.int().min(9).max(9), z.int().min(11).max(11)]),
+        }).strict(),
+        z.object({
+          day: z.literal("fri"),
+          range: z.tuple([z.int().min(14).max(14), z.int().min(16).max(16)]),
+        }).strict(),
+      ]),
+      metadata: z.record(
+        z.string().regex(/^(alpha|beta)$/),
+        z.object({
+          state: z.literal("ready"),
+          score: z.number().min(0.5).max(0.5),
+        }).strict(),
+      ),
+    }).strict(),
+    execute: (input) => {
+      state.nestedObjects.push(input);
+      return "ok:nested-object";
+    },
+  });
+
+  const tools = {
+    plainString: plainStringTool,
+    constrainedString: constrainedStringTool,
+    decimalNumber: decimalNumberTool,
+    constrainedInteger: constrainedIntegerTool,
+    void: voidTool,
+    simpleObject: simpleObjectTool,
+    nestedObject: nestedObjectTool,
+  } as const;
+
+  const marker = "LIVE_STRUCTURED_TOOL_PARAMETERS_COMPLETE";
+
+  return {
+    expected,
+    state,
+    tools,
+    marker,
+    instructions: [
+      "You are running a live SDK integration test for structured tool parameters.",
+      "Call every provided tool exactly once.",
+      "Follow each tool description exactly and do not add extra fields.",
+      `After all tool calls, respond with exactly ${marker} and nothing else.`,
+    ].join(" "),
+  };
+}
+
+function assertStructuredToolPayload(
+  items: WithTraceId<StreamItem>[],
+  toolName: string,
+  expected: unknown,
+) {
+  const seenToolStarts = items
+    .filter((item): item is Extract<WithTraceId<StreamItem>, { type: "tool_use_start" }> =>
+      item.type === "tool_use_start"
+    )
+    .map((item) => item.kind);
+
+  assert(
+    items.some((item) => item.type === "tool_use_start" && item.kind === toolName),
+    `expected ${toolName} tool_use_start, saw starts for: ${JSON.stringify(seenToolStarts)}`,
+  );
+
+  const toolUse = findToolUse(items, toolName);
+  assert(toolUse, `expected ${toolName} tool_use item, saw starts for: ${JSON.stringify(seenToolStarts)}`);
+
+  if (expected === undefined) {
+    assertEquals(toolUse.content, undefined);
+    return;
+  }
+
+  assert(toolUse.content, `expected ${toolName} content`);
+  assertEquals(JSON.parse(toolUse.content), expected);
+}
+
 function createCalculatorFixtures() {
   const state = {
     calls: [] as {
@@ -278,7 +494,10 @@ export async function runAgentToolStreamingTest(
   await t.step("assert final streamed output", () => {
     assert(result, "expected final agent result");
     assert(items.some((item) => item.type === "delta_output_text"), "expected streamed text output");
-    assert(result.outputText.trim().endsWith(fixtures.marker), `expected final output to end with ${fixtures.marker}`);
+    assert(
+      result.outputText.includes(fixtures.marker),
+      `expected final output to include ${fixtures.marker} but instead outputted ${result.outputText}`,
+    );
   });
 
   await t.step("assert tool execution counts", () => {
@@ -314,6 +533,84 @@ export async function runStructuredOutputStreamingTest(
   await t.step("assert structured output parsed", () => {
     assert(result, "expected final structured output result");
     assertEquals(result.output, fixtures.expected);
+  });
+}
+
+export async function runStructuredToolParameterStreamingTest(
+  t: Deno.TestContext,
+  options: {
+    model: Model;
+  },
+) {
+  const fixtures = createStructuredToolParameterFixtures();
+  const agent = new Agent({
+    model: options.model,
+    instructions: fixtures.instructions,
+    tools: [
+      fixtures.tools.plainString,
+      fixtures.tools.constrainedString,
+      fixtures.tools.decimalNumber,
+      fixtures.tools.constrainedInteger,
+      fixtures.tools.void,
+      fixtures.tools.simpleObject,
+      fixtures.tools.nestedObject,
+    ],
+  });
+
+  let items: WithTraceId<StreamItem>[] = [];
+  let result: AgentRunResult<unknown> | undefined;
+
+  const collectedAgentStream = await t.step("collect structured tool parameter stream", async () => {
+    const collected = await collectAgentStream(agent.stream("Run the structured tool parameter test now.", {
+      signal: AbortSignal.timeout(INTEGRATION_TIMEOUT_MS),
+    }));
+    items = collected.items;
+    result = collected.result;
+  });
+
+  if (!collectedAgentStream) return;
+
+  await t.step("plain string tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.plainString.name, fixtures.expected.plainString);
+    assertEquals(fixtures.state.plainStrings, [fixtures.expected.plainString]);
+  });
+
+  await t.step("constrained string tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.constrainedString.name, fixtures.expected.constrainedString);
+    assertEquals(fixtures.state.constrainedStrings, [fixtures.expected.constrainedString]);
+  });
+
+  await t.step("number tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.decimalNumber.name, fixtures.expected.decimalNumber);
+    assertEquals(fixtures.state.decimalNumbers, [fixtures.expected.decimalNumber]);
+  });
+
+  await t.step("integer tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.constrainedInteger.name, fixtures.expected.constrainedInteger);
+    assertEquals(fixtures.state.constrainedIntegers, [fixtures.expected.constrainedInteger]);
+  });
+
+  await t.step("void tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.void.name, undefined);
+    assertEquals(fixtures.state.voidCalls, 1);
+  });
+
+  await t.step("simple object tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.simpleObject.name, fixtures.expected.simpleObject);
+    assertEquals(fixtures.state.simpleObjects, [fixtures.expected.simpleObject]);
+  });
+
+  await t.step("nested object tool uses the expected payload and parsed input", () => {
+    assertStructuredToolPayload(items, fixtures.tools.nestedObject.name, fixtures.expected.nestedObject);
+    assertEquals(fixtures.state.nestedObjects, [fixtures.expected.nestedObject]);
+  });
+
+  await t.step("assert final streamed output for structured tool parameters", () => {
+    assert(result, "expected final agent result");
+    assert(
+      result.outputText.includes(fixtures.marker),
+      `expected final output to include ${fixtures.marker} but instead outputted ${result.outputText}`,
+    );
   });
 }
 


### PR DESCRIPTION
This PR extracts the Anthropic structured output schema compatibility translation into a shared thing that now also allows OpenResponses and OpenAI Completions adapters to use it.

It also fixed an issue where these providers sometimes failed to unwrap primitives in tool call parameters.

This fixes some issues that were sometimes occuring with these providers that caused tool call failures.

It also adds tests for all adapters to make sure this won't become a regression again.