### PR TITLE
fix: opus 4.7 omitting reasoning by default

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -13,8 +13,8 @@ export type { ClassifiedError, ErrorKind } from "./src/errors.ts";
 export { DEFAULT_RETRY_STRATEGY, determineRetryBehavior, resolveRetryStrategy } from "./src/retry.ts";
 export type { ResolvedRetryStrategy, RetryBehavior, RetryStrategy } from "./src/retry.ts";
 
-export { addStreamItem, convertChatItemsToStream } from "./src/client.ts";
 export { cli } from "./src/cli.ts";
+export { addStreamItem, convertChatItemsToStream } from "./src/client.ts";
 
 export type { CliIo, CliOptions } from "./src/cli.ts";
 export { ModelOutput, Tool } from "./src/tool.ts";
@@ -37,6 +37,7 @@ export type {
   SupportedEffortLevel as AnthropicSupportedEffortLevel,
   SupportedThinkingLevel as AnthropicSupportedThinkingLevel,
   SupportsInterleaved,
+  ThinkingDisplay as AnthropicThinkingDisplay,
   ThinkingLevel,
 } from "./src/adapters/anthropic/models.ts";
 

--- a/src/adapters/anthropic/adapter.ts
+++ b/src/adapters/anthropic/adapter.ts
@@ -1,5 +1,4 @@
 import Anthropic from "@anthropic-ai/sdk";
-import { assert } from "@std/assert";
 import { isStructuredOutputRetryFeedback } from "../../constants.ts";
 import { type ClassifiedError, createClassifiedError } from "../../errors.ts";
 import type { AdapterStreamIterator, ChatItem } from "../../types.ts";
@@ -283,6 +282,7 @@ ${JSON.stringify(structuredOutput.originalJsonSchema, null, 2)}
     }, { signal });
 
     const parts: ChatItem[] = [];
+    const reasoningSignatures = new Map<number, string>();
     for await (const part of response) {
       if (part.type === "content_block_delta") {
         const { delta } = part;
@@ -309,9 +309,10 @@ ${JSON.stringify(structuredOutput.originalJsonSchema, null, 2)}
             index: part.index,
           };
         } else if (delta.type === "signature_delta") {
-          const thinkingPart = parts[part.index];
-          assert(thinkingPart.type === "output_reasoning");
-          signatureMap.set(thinkingPart.content, delta.signature);
+          if (!parts[part.index]) {
+            parts[part.index] = { type: "output_reasoning", content: "" };
+          }
+          reasoningSignatures.set(part.index, delta.signature);
         } else if (delta.type === "input_json_delta") {
           parts[part.index].content += delta.partial_json;
         }
@@ -331,10 +332,31 @@ ${JSON.stringify(structuredOutput.originalJsonSchema, null, 2)}
             kind: tool?.original.name ?? block.name,
             tool_use_id: block.id,
           };
+        } else if (part.content_block.type === "thinking") {
+          parts[part.index] = {
+            type: "output_reasoning",
+            content: part.content_block.thinking,
+          };
+          if (part.content_block.signature) {
+            reasoningSignatures.set(part.index, part.content_block.signature);
+          }
+          if (part.content_block.thinking) {
+            yield {
+              type: "delta_output_reasoning",
+              delta: part.content_block.thinking,
+              index: part.index,
+            };
+          }
         }
       } else if (part.type === "content_block_stop") {
         const endingPart = parts[part.index];
-        if (endingPart.type === "tool_use") {
+        if (endingPart?.type === "output_reasoning") {
+          const signature = reasoningSignatures.get(part.index);
+          if (signature && endingPart.content) {
+            signatureMap.set(endingPart.content, signature);
+          }
+          reasoningSignatures.delete(part.index);
+        } else if (endingPart.type === "tool_use") {
           const tool = normalizedTools.find((tool) => tool.anthropic.name === endingPart.kind);
           const restoredContent = endingPart.content
             ? JSON.stringify(

--- a/src/adapters/anthropic/model.ts
+++ b/src/adapters/anthropic/model.ts
@@ -10,6 +10,7 @@ import {
   type SupportedEffortLevel,
   type SupportedThinkingLevel,
   type SupportsInterleaved,
+  type ThinkingDisplay,
   type ThinkingLevel,
 } from "./models.ts";
 
@@ -32,12 +33,13 @@ export type AnthropicModelOptions<TModel extends AnthropicModels> =
   & ThinkingLevelOption<TModel>
   & EffortOption<TModel>
   & InterleavedOption<TModel>
-  & { baseUrl?: string; apiKey?: string };
+  & { baseUrl?: string; apiKey?: string; thinkingDisplay?: ThinkingDisplay };
 
 export class AnthropicModel<TModel extends AnthropicModels = AnthropicModels> extends Model<TModel> {
   adapter: AnthropicAdapter<TModel>;
   readonly thinkingLevel: SupportedThinkingLevel<TModel> | undefined;
   readonly effort: SupportedEffortLevel<TModel> | undefined;
+  readonly thinkingDisplay: ThinkingDisplay;
   readonly interleaved: boolean | undefined;
 
   constructor(options: AnthropicModelOptions<TModel>) {
@@ -45,9 +47,10 @@ export class AnthropicModel<TModel extends AnthropicModels = AnthropicModels> ex
 
     const modelConfig = anthropicModelThinkingSupport[options.model];
     // Cast to access fields that are conditionally typed per model
-    const { thinkingLevel, effort, interleaved } = options as {
+    const { thinkingLevel, effort, thinkingDisplay, interleaved } = options as {
       thinkingLevel?: ThinkingLevel;
       effort?: EffortLevel;
+      thinkingDisplay?: ThinkingDisplay;
       interleaved?: boolean;
     };
 
@@ -60,12 +63,14 @@ export class AnthropicModel<TModel extends AnthropicModels = AnthropicModels> ex
       | SupportedEffortLevel<TModel>
       | undefined;
 
+    this.thinkingDisplay = thinkingDisplay ?? "summarized";
     this.interleaved = interleaved;
 
     const thinkingConfig = getAnthropicMessagesStreamConfig({
       model: options.model,
       thinkingLevel: this.thinkingLevel as ThinkingLevel | undefined,
       effort: this.effort as EffortLevel | undefined,
+      thinkingDisplay: this.thinkingDisplay,
       interleaved: this.interleaved,
     });
 

--- a/src/adapters/anthropic/models.ts
+++ b/src/adapters/anthropic/models.ts
@@ -9,6 +9,7 @@ import type {
 } from "./types.ts";
 
 export type ThinkingLevel = "adaptive" | "minimal" | "low" | "medium" | "high";
+export type ThinkingDisplay = "summarized" | "omitted";
 
 export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -223,11 +224,13 @@ export interface GetAnthropicMessagesStreamConfigOptions {
   model: AnthropicModels;
   thinkingLevel?: ThinkingLevel;
   effort?: EffortLevel;
+  thinkingDisplay?: ThinkingDisplay;
   interleaved?: boolean;
 }
 
 export function getAnthropicMessagesStreamConfig(
-  { model, thinkingLevel, effort, interleaved }: GetAnthropicMessagesStreamConfigOptions,
+  { model, thinkingLevel, effort, thinkingDisplay = "summarized", interleaved }:
+    GetAnthropicMessagesStreamConfigOptions,
 ): AnthropicMessagesStreamConfig {
   const support = anthropicModelThinkingSupport[model];
 
@@ -240,7 +243,7 @@ export function getAnthropicMessagesStreamConfig(
     case "adaptive": {
       // Interleaved thinking is enabled automatically by adaptive thinking - no beta header needed.
       return {
-        thinking: { type: "adaptive" },
+        thinking: { type: "adaptive", display: thinkingDisplay },
         output_config: outputConfig,
         betas,
       };
@@ -258,7 +261,7 @@ export function getAnthropicMessagesStreamConfig(
       }
       // Adaptive thinking mode - interleaved is automatic, no beta header needed.
       return {
-        thinking: { type: "adaptive" },
+        thinking: { type: "adaptive", display: thinkingDisplay },
         output_config: outputConfig,
         betas,
       };

--- a/tests/adapters/anthropic.test.ts
+++ b/tests/adapters/anthropic.test.ts
@@ -1,11 +1,12 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { assert, assertEquals } from "@std/assert";
 import z from "zod";
-import { addStreamItem, AnthropicModel, type ChatItem, Tool } from "../../mod.ts";
+import { addStreamItem, Agent, AnthropicModel, type ChatItem, type StreamItem, Tool } from "../../mod.ts";
 import { AnthropicAdapter } from "../../src/adapters/anthropic/adapter.ts";
 import { getAnthropicMessagesStreamConfig } from "../../src/adapters/anthropic/models.ts";
 import { createAnthropicCompatibleSchema, normalizeAnthropicTools } from "../../src/adapters/anthropic/utils.ts";
 import {
+  collectAdapterStream,
   createToolFixtures,
   INTEGRATION_TIMEOUT_MS,
   runAdapterToolStreamingTest,
@@ -36,7 +37,7 @@ Deno.test({
       client: createAnthropicClient(),
       streamConfig: getAnthropicMessagesStreamConfig({
         model: "claude-opus-4-7",
-        effort: "low",
+        effort: "high",
       }),
     });
 
@@ -118,7 +119,25 @@ Deno.test({
     assertEquals(
       getAnthropicMessagesStreamConfig({ model: "claude-opus-4-7", effort: "xhigh" }),
       {
-        thinking: { type: "adaptive" },
+        thinking: { type: "adaptive", display: "summarized" },
+        output_config: { effort: "xhigh" },
+        betas: undefined,
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "claude-opus-4-7 supports omitted thinking display",
+  fn() {
+    assertEquals(
+      getAnthropicMessagesStreamConfig({
+        model: "claude-opus-4-7",
+        effort: "xhigh",
+        thinkingDisplay: "omitted",
+      }),
+      {
+        thinking: { type: "adaptive", display: "omitted" },
         output_config: { effort: "xhigh" },
         betas: undefined,
       },
@@ -455,4 +474,213 @@ Deno.test("Anthropic structured output streamed as text is restored before emiss
       responseStrategy: { tone: ["casual", "warm"] },
     }),
   }]);
+});
+
+Deno.test("Anthropic ignores signature deltas when thinking display omits reasoning text", async () => {
+  const client = {
+    beta: {
+      messages: {
+        stream() {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield { type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "sig_1" } };
+              yield { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "done" } };
+              yield { type: "content_block_stop", index: 1 };
+            },
+            finalMessage() {
+              return { usage: { input_tokens: 0, output_tokens: 0 } };
+            },
+          };
+        },
+      },
+    },
+  } as unknown as Anthropic;
+
+  const adapter = new AnthropicAdapter({
+    model: "claude-opus-4-7",
+    client,
+    streamConfig: getAnthropicMessagesStreamConfig({
+      model: "claude-opus-4-7",
+      effort: "high",
+      thinkingDisplay: "omitted",
+    }),
+  });
+
+  const { items, metadata } = await collectAdapterStream(adapter.stream({
+    history: [],
+    instructions: "test",
+    tools: [],
+    signal: AbortSignal.abort(),
+  }));
+
+  assertEquals(items, [{
+    type: "delta_output_text",
+    delta: "done",
+    index: 1,
+  }]);
+  assertEquals(metadata, { inputTokens: 0, outputTokens: 0 });
+});
+
+Deno.test("Anthropic attaches signatures after reasoning block completion", async () => {
+  const client = {
+    beta: {
+      messages: {
+        stream() {
+          return {
+            async *[Symbol.asyncIterator]() {
+              yield {
+                type: "content_block_start",
+                index: 0,
+                content_block: { type: "thinking", thinking: "", signature: "" },
+              };
+              yield { type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "sig_123" } };
+              yield {
+                type: "content_block_delta",
+                index: 0,
+                delta: { type: "thinking_delta", thinking: "Let me think." },
+              };
+              yield { type: "content_block_stop", index: 0 };
+            },
+            finalMessage() {
+              return { usage: { input_tokens: 0, output_tokens: 0 } };
+            },
+          };
+        },
+      },
+    },
+  } as unknown as Anthropic;
+
+  const adapter = new AnthropicAdapter({
+    model: "claude-opus-4-7",
+    client,
+    streamConfig: getAnthropicMessagesStreamConfig({
+      model: "claude-opus-4-7",
+      effort: "high",
+      thinkingDisplay: "summarized",
+    }),
+  });
+
+  const stream = adapter.stream({
+    history: [],
+    instructions: "test",
+    tools: [],
+    signal: AbortSignal.abort(),
+  });
+
+  const items: StreamItem[] = [];
+  const rebuiltHistory: ChatItem[] = [];
+  while (true) {
+    const next = await stream.next();
+    if (next.done) break;
+    items.push(next.value);
+    addStreamItem(rebuiltHistory, next.value);
+  }
+
+  assertEquals(items, [{
+    type: "delta_output_reasoning",
+    index: 0,
+    delta: "Let me think.",
+  }]);
+  assertEquals(rebuiltHistory, [{
+    type: "output_reasoning",
+    content: "Let me think.",
+  }]);
+
+  const history = await adapter.getHistory(rebuiltHistory, [], AbortSignal.abort());
+  assertEquals(history, [{
+    role: "assistant",
+    content: [{
+      type: "thinking",
+      thinking: "Let me think.",
+      signature: "sig_123",
+    }],
+  }]);
+});
+
+async function checkReasoning(model: AnthropicModel, options: { shouldStreamReasoning: boolean }) {
+  const agent = new Agent({
+    model,
+    instructions: "You are a puzzle solver.",
+  });
+
+  const collectedItems: StreamItem[] = [];
+  for await (
+    const item of agent.stream(`\
+5 pirates of different ages have a treasure of 100 gold coins. On their ship, they decide to split the coins using this scheme:
+The oldest pirate proposes how to share the coins, and ALL pirates (including the oldest) vote for or against it.
+If 50% or more of the pirates vote for it, then the coins will be shared that way. Otherwise, the pirate proposing the scheme will be thrown overboard, and the process is repeated with the pirates that remain.
+As pirates tend to be a bloodthirsty bunch, if a pirate would get the same number of coins if he voted for or against a proposal, he will vote against so that the pirate who proposed the plan will be thrown overboard.
+Assuming that all 5 pirates are intelligent, rational, greedy, and do not wish to die, (and are rather good at math for pirates) what will happen?`)
+  ) {
+    collectedItems.push(item);
+  }
+
+  const reasoningItem = collectedItems.find((item) => item.type === "delta_output_reasoning");
+  assertEquals(Boolean(reasoningItem), options.shouldStreamReasoning);
+  assert(collectedItems.find((item) => item.type === "delta_output_text"));
+}
+
+Deno.test({
+  name: "Anthropic properly streams reasoning for claude-sonnet-4-5",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await checkReasoning(new AnthropicModel({ model: "claude-sonnet-4-5", thinkingLevel: "medium" }), {
+    shouldStreamReasoning: true,
+  });
+});
+
+Deno.test({
+  name: "Anthropic properly streams reasoning for claude-sonnet-4-6",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await checkReasoning(new AnthropicModel({ model: "claude-sonnet-4-6", effort: "medium" }), {
+    shouldStreamReasoning: true,
+  });
+});
+
+Deno.test({
+  name: "Anthropic properly streams reasoning for claude-opus-4-5",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await checkReasoning(new AnthropicModel({ model: "claude-opus-4-5", effort: "medium" }), {
+    shouldStreamReasoning: true,
+  });
+});
+
+Deno.test({
+  name: "Anthropic properly streams reasoning for claude-opus-4-6",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await checkReasoning(new AnthropicModel({ model: "claude-opus-4-6", effort: "medium" }), {
+    shouldStreamReasoning: true,
+  });
+});
+Deno.test({
+  name: "Anthropic properly streams summarized reasoning for claude-opus-4-7",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await checkReasoning(new AnthropicModel({ model: "claude-opus-4-7", effort: "max" }), {
+    shouldStreamReasoning: true,
+  });
+});
+
+Deno.test({
+  name: "Anthropic supports omitted reasoning display for claude-opus-4-7",
+  ignore: !HAS_ANTHROPIC_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async () => {
+  await checkReasoning(new AnthropicModel({ model: "claude-opus-4-7", effort: "max", thinkingDisplay: "omitted" }), {
+    shouldStreamReasoning: false,
+  });
 });


### PR DESCRIPTION
[Opus 4.7](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) defaults to `display: "omitted"` now for some reason and we did not handle that well