### PR TITLE
feat: improve context overflow classification

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -5,6 +5,7 @@ export type {
   AgentRunResult,
   BeforeModelCall as BeforeModelCallFn,
   HandleModelError as HandleModelErrorFn,
+  ModelCallReason,
 } from "./src/agent.ts";
 
 export { classifyError, createClassifiedError, ERROR_KINDS } from "./src/errors.ts";

--- a/src/adapters/shared/classify_error.ts
+++ b/src/adapters/shared/classify_error.ts
@@ -16,6 +16,8 @@ export function classifyOpenAIError(error: unknown): ClassifiedError | null {
     return createClassifiedError("server", error, error.status);
   } else if (error instanceof OpenAI.APIUserAbortError) {
     return createClassifiedError("aborted", error, error.status);
+  } else if (error instanceof OpenAI.APIError && error.code === "context_length_exceeded") {
+    return createClassifiedError("context_overflow", error, error.status);
   }
   return null;
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -68,15 +68,38 @@ export interface AgentRunOptions {
   signal?: AbortSignal;
 }
 
+export type ModelCallReason =
+  | "init"
+  | "tool"
+  | "retry-missing-output"
+  | "retry-malformed-output"
+  | "retry-context-compaction"
+  | "retry-transient"
+  | "retry-model-switch";
+
+interface BeforeModelCallContext {
+  turn: number;
+  reason: ModelCallReason;
+  usage: TokenUsage;
+  model: ModelInfo;
+}
+
+interface HandleModelErrorContext {
+  turn: number;
+  attempt: number;
+  usage: TokenUsage;
+  model: ModelInfo;
+}
+
 export type BeforeModelCall = (
   history: ChatItem[],
-  context: { turn: number; reason: string; usage: TokenUsage },
+  context: BeforeModelCallContext,
 ) => AsyncGenerator<ContextSummaryStartEvent, ChatItem[]>;
 
 export type HandleModelError = (
-  error: unknown,
+  error: ClassifiedError,
   history: ChatItem[],
-  context: { turn: number; attempt: number; usage: TokenUsage },
+  context: HandleModelErrorContext,
 ) => AsyncGenerator<ContextSummaryStartEvent, ChatItem[] | null>;
 
 export interface AgentOptions<zO, zI, Tools extends AnyTool[]> {
@@ -305,7 +328,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
 
       const pendingTools = new Map<string, Promise<RunToolResult>>();
       const history: WithTraceId<ChatItem>[] = [];
-      let modelCallReason = "init";
+      let modelCallReason: ModelCallReason = "init";
 
       for (let turn = 0; turn < this.#maxTurns; turn++) {
         signal.throwIfAborted();
@@ -395,7 +418,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
     pendingTools: Map<string, Promise<RunToolResult>>;
     toolSignal: AbortSignal;
     agentTrace: ActiveTrace<"agent">;
-    modelCallReason: string;
+    modelCallReason: ModelCallReason;
     turn: number;
     usage: TokenUsage;
   }): AsyncGenerator<
@@ -427,6 +450,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
       modelLoop: while (currentModelIndex < this.#models.length) {
         const model = this.#models[currentModelIndex];
         const adapter = model.adapter;
+        const currentModel: ModelInfo = { provider: adapter.name, model: adapter.model };
 
         // Emit model_switched event when switching to a different model after a failure
         if (previousModel && (previousModel.provider !== adapter.name || previousModel.model !== adapter.model)) {
@@ -434,7 +458,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
             type: "model_switched",
             index: history.length,
             from: previousModel,
-            to: { provider: adapter.name, model: adapter.model },
+            to: currentModel,
             cause: lastSwitchCause?.error,
             classified: lastSwitchCause?.classified,
             trace: agentTrace.id,
@@ -465,6 +489,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
                 turn,
                 reason: modelCallReason,
                 usage: options.usage,
+                model: currentModel,
               }),
               baseHistory,
               history.length,
@@ -506,7 +531,12 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
             // Always try handleModelError if provided - let the user decide what errors to handle
             if (attempt < this.#maxRecoveryAttempts && this.#handleModelError) {
               const { assembled: recovered, compactionItems: recoveryCompactionItems } = yield* consumeCompactionEvents(
-                this.#handleModelError(error, baseHistory, { turn, attempt, usage: options.usage }),
+                this.#handleModelError(classified, baseHistory, {
+                  turn,
+                  attempt,
+                  usage: options.usage,
+                  model: currentModel,
+                }),
                 baseHistory,
                 history.length,
                 agentTrace.id,
@@ -696,7 +726,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
     agentTrace: ActiveTrace<"agent">,
   ):
     | { ok: true; output: ResolveAgentOutput<zO, Tools> }
-    | { ok: false; reason: string; feedback?: string } {
+    | { ok: false; reason: ModelCallReason; feedback?: string } {
     if (!this.#output) {
       return { ok: true, output: undefined as ResolveAgentOutput<zO, Tools> };
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -113,6 +113,7 @@ function isLikelyContextOverflow(text: string): boolean {
   const lower = text.toLowerCase();
   return (
     lower.includes("prompt is too long") ||
+    lower.includes("request body too large") ||
     lower.includes("token count exceed") ||
     lower.includes("context_length_exceeded") ||
     lower.includes("context window") ||

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -114,10 +114,13 @@ function isLikelyContextOverflow(text: string): boolean {
   return (
     lower.includes("prompt is too long") ||
     lower.includes("token count exceed") ||
+    lower.includes("context_length_exceeded") ||
+    lower.includes("context window") ||
     lower.includes("maximum number of tokens allowed") ||
     lower.includes("token limit") ||
     lower.includes("context length") ||
     lower.includes("maximum context length") ||
+    (lower.includes("exceeds") && lower.includes("context")) ||
     (lower.includes("too long") && lower.includes("token"))
   );
 }

--- a/tests/simple/adapter-errors.test.ts
+++ b/tests/simple/adapter-errors.test.ts
@@ -1,4 +1,3 @@
-import { assertEquals } from "@std/assert";
 import {
   APIConnectionError,
   APIConnectionTimeoutError,
@@ -9,6 +8,7 @@ import {
   PermissionDeniedError,
   RateLimitError,
 } from "@anthropic-ai/sdk";
+import { assertEquals } from "@std/assert";
 import {
   APIConnectionError as OpenAIAPIConnectionError,
   APIConnectionTimeoutError as OpenAIAPIConnectionTimeoutError,
@@ -19,11 +19,11 @@ import {
   PermissionDeniedError as OpenAIPermissionDeniedError,
   RateLimitError as OpenAIRateLimitError,
 } from "openai";
+import type { Adapter } from "../../src/adapters/adapter.ts";
 import { AnthropicAdapter } from "../../src/adapters/anthropic/adapter.ts";
 import { OpenResponsesAdapter } from "../../src/adapters/open_responses/adapter.ts";
 import { OpenAICompletionsAdapter } from "../../src/adapters/openai_completions/adapter.ts";
 import { type ClassifiedError, classifyError, type ErrorKind } from "../../src/errors.ts";
-import type { Adapter } from "../../src/adapters/adapter.ts";
 
 // Mirrors the real pipeline in agent.ts: adapter-specific classification first, heuristic fallback second
 function classify(adapter: Adapter<string>, error: unknown): ClassifiedError {
@@ -199,6 +199,23 @@ const testCases: AdapterErrorTestCase[] = [
     expectedKind: "context_overflow",
   },
   {
+    name: "OpenResponses: APIError with context_length_exceeded code -> context_overflow",
+    adapter: openResponsesAdapter,
+    error: new OpenAIAPIError(
+      400,
+      {
+        message: "Your input exceeds the context window of this model. Please adjust your input and try again.",
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+        param: "input",
+      },
+      "Your input exceeds the context window of this model. Please adjust your input and try again.",
+      new Headers(),
+    ),
+    expectedKind: "context_overflow",
+    expectedStatus: 400,
+  },
+  {
     name: "OpenResponses: unknown error falls through to heuristics",
     adapter: openResponsesAdapter,
     error: new TypeError("Cannot read property"),
@@ -241,6 +258,23 @@ const testCases: AdapterErrorTestCase[] = [
     adapter: openAICompletionsAdapter,
     error: new OpenAIAPIError(503, { message: "Service overloaded" }, "Service overloaded", new Headers()),
     expectedKind: "model_unavailable",
+  },
+  {
+    name: "OpenAICompletions: APIError with context_length_exceeded code -> context_overflow",
+    adapter: openAICompletionsAdapter,
+    error: new OpenAIAPIError(
+      400,
+      {
+        message: "Your input exceeds the context window of this model. Please adjust your input and try again.",
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+        param: "input",
+      },
+      "Your input exceeds the context window of this model. Please adjust your input and try again.",
+      new Headers(),
+    ),
+    expectedKind: "context_overflow",
+    expectedStatus: 400,
   },
   {
     name: "OpenAICompletions: unknown error falls through to heuristics",

--- a/tests/simple/adapter-errors.test.ts
+++ b/tests/simple/adapter-errors.test.ts
@@ -199,6 +199,18 @@ const testCases: AdapterErrorTestCase[] = [
     expectedKind: "context_overflow",
   },
   {
+    name: "OpenResponses: APIError with request body too large -> context_overflow",
+    adapter: openResponsesAdapter,
+    error: new OpenAIAPIError(
+      413,
+      { message: "Request body too large" },
+      "Request body too large",
+      new Headers(),
+    ),
+    expectedKind: "context_overflow",
+    expectedStatus: 413,
+  },
+  {
     name: "OpenResponses: APIError with context_length_exceeded code -> context_overflow",
     adapter: openResponsesAdapter,
     error: new OpenAIAPIError(

--- a/tests/simple/agent.test.ts
+++ b/tests/simple/agent.test.ts
@@ -343,8 +343,14 @@ Deno.test("handleModelError recovers from context window errors", async () => {
   const agent = new Agent({
     model: new ContextWindowTestModel(3),
     instructions: "You are a friendly assistant",
-    async *handleModelError(error, history, _context) {
-      if (error instanceof Error && error.message.includes("context length")) {
+    async *handleModelError(error, history, context) {
+      assertEquals(error.kind, "context_overflow");
+      assertEquals(context.turn, 0);
+      assertEquals(context.attempt, 0);
+      assertEquals(context.model.provider, "deterministic");
+      assertEquals(context.model.model, "deterministic");
+
+      if (error.original instanceof Error && error.original.message.includes("context length")) {
         yield { type: "context_summary_start" as const };
         recoveryCalls += 1;
         return history.filter((item) => item.type !== "input_file");
@@ -363,6 +369,34 @@ Deno.test("handleModelError recovers from context window errors", async () => {
 
   assert(recoveryCalls > 0);
   assertEquals(run.outputText, "Recovery successful!");
+});
+
+Deno.test("beforeModelCall receives current model in context", async () => {
+  let receivedContext:
+    | { turn: number; reason: string; model: { provider: string; model: string } }
+    | undefined;
+
+  const agent = new Agent({
+    model: new DeterministicTestModel(),
+    instructions: "Test agent",
+    // deno-lint-ignore require-yield
+    async *beforeModelCall(history, context) {
+      receivedContext = {
+        turn: context.turn,
+        reason: context.reason,
+        model: context.model,
+      };
+      return history;
+    },
+  });
+
+  await agent.run("Hello");
+
+  assert(receivedContext);
+  assertEquals(receivedContext.turn, 0);
+  assertEquals(receivedContext.reason, "init");
+  assertEquals(receivedContext.model.provider, "deterministic");
+  assertEquals(receivedContext.model.model, "deterministic");
 });
 
 Deno.test("handleModelError returning null falls through to normal retry", async () => {

--- a/tests/simple/errors.test.ts
+++ b/tests/simple/errors.test.ts
@@ -181,6 +181,11 @@ const testCases: ClassifyErrorTestCase[] = [
     expected: { kind: "context_overflow" },
   },
   {
+    name: "classifies context overflow from request body too large message",
+    error: { status: 413, message: "Request body too large" },
+    expected: { kind: "context_overflow", status: 413 },
+  },
+  {
     name: "classifies context overflow from context_length_exceeded code",
     error: { error: { code: "context_length_exceeded" } },
     expected: { kind: "context_overflow" },

--- a/tests/simple/errors.test.ts
+++ b/tests/simple/errors.test.ts
@@ -171,8 +171,18 @@ const testCases: ClassifyErrorTestCase[] = [
     expected: { kind: "context_overflow" },
   },
   {
+    name: "classifies context overflow from context window message",
+    error: "Your input exceeds the context window of this model. Please adjust your input and try again.",
+    expected: { kind: "context_overflow" },
+  },
+  {
     name: "classifies context overflow from token limit message",
     error: "Request exceeds token limit",
+    expected: { kind: "context_overflow" },
+  },
+  {
+    name: "classifies context overflow from context_length_exceeded code",
+    error: { error: { code: "context_length_exceeded" } },
     expected: { kind: "context_overflow" },
   },
 


### PR DESCRIPTION
1. OpenAI depended on heuristics to be correct instead of relying on proper context provided from the API
2. Make `ModelCallReason` strictly typed because it doesn't take any arbitrary strings