### PR TITLE
fix: tool definition reliance for history restoration

### DIFF
--- a/src/adapters/anthropic/adapter.ts
+++ b/src/adapters/anthropic/adapter.ts
@@ -1,6 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { isStructuredOutputRetryFeedback } from "../../constants.ts";
 import { type ClassifiedError, createClassifiedError } from "../../errors.ts";
+import { normalizeToolName } from "../../tool.ts";
 import type { AdapterStreamIterator, ChatItem } from "../../types.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
 import type { SchemaCompatibility } from "../shared/schema_compatibility.ts";
@@ -125,7 +126,7 @@ export class AnthropicAdapter<TModel extends AnthropicModels> extends Adapter<TM
             content: [{
               type: "tool_use",
               id: historyItem.tool_use_id,
-              name: tool?.anthropic.name ?? historyItem.kind,
+              name: tool?.anthropic.name ?? normalizeToolName(historyItem.kind),
               input: tool?.compatibility ? tool.compatibility.toProvider(content) : content,
             }],
           });

--- a/src/adapters/google_genai/adapter.ts
+++ b/src/adapters/google_genai/adapter.ts
@@ -6,6 +6,7 @@ import type {
   ThinkingConfig,
 } from "@google/genai";
 import { assert } from "@std/assert";
+import { normalizeToolName } from "../../tool.ts";
 import type { AdapterStreamIterator, ChatItem, ChatItemToolUse } from "../../types.ts";
 import { hashString } from "../../util.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
@@ -130,7 +131,7 @@ export abstract class GoogleGenAiAdapter<TModel extends GoogleModels> extends Ad
             parts: [{
               functionCall: {
                 id: item.tool_use_id,
-                name: tool?.google.name ?? item.kind,
+                name: tool?.google.name ?? normalizeToolName(item.kind),
                 args: tool?.wrapperObject ? { content } : content,
               },
               thoughtSignature,
@@ -143,17 +144,19 @@ export abstract class GoogleGenAiAdapter<TModel extends GoogleModels> extends Ad
             candidate.type === "tool_use" &&
             candidate.tool_use_id === item.tool_use_id
           );
-          assert(toolCall);
+          assert(toolCall, "Tool result is present in the history without initial tool call");
 
-          const definition = toolMap.find((x) => x.original.name === toolCall.kind);
-          assert(definition);
+          // We don't actually assert the definition's existence. Chat history might get reused without previously existing tool calls,
+          //  e.g. for context compaction, or when user wants to implement custom tool selection system.
+          // The kind is enough to normalize to the original function name.
+          const definition = toolMap.find((tool) => tool.original.name === toolCall.kind);
 
           googleHistory.push({
             role: "user",
             parts: [{
               functionResponse: {
                 id: item.tool_use_id,
-                name: definition.google.name,
+                name: definition?.google.name ?? normalizeToolName(toolCall.kind),
                 response: { content: item.content },
               },
             }],
@@ -239,7 +242,7 @@ export abstract class GoogleGenAiAdapter<TModel extends GoogleModels> extends Ad
         } else if (part.functionCall) {
           const func = part.functionCall;
           const funcId = func.id ?? crypto.randomUUID();
-          assert(func.name);
+          assert(func.name, "Function calls must have a name");
           const tool = normalizedTools.find((tool) => tool.google.name === func.name);
 
           if (part.thoughtSignature) {

--- a/src/adapters/open_responses/adapter.ts
+++ b/src/adapters/open_responses/adapter.ts
@@ -13,6 +13,7 @@ import type { ReasoningEffort } from "openai/resources/shared";
 
 import { isStructuredOutputRetryFeedback, RETRY_RESUMABILITY_PROMPT } from "../../constants.ts";
 import type { ClassifiedError } from "../../errors.ts";
+import { normalizeToolName } from "../../tool.ts";
 import type { AdapterStreamIterator, ChatItem } from "../../types.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
 import { classifyOpenAIError } from "../shared/classify_error.ts";
@@ -204,7 +205,7 @@ export class OpenResponsesAdapter<TModel extends string> extends Adapter<TModel>
             type: "function_call",
             status: "completed",
             call_id: historyItem.tool_use_id,
-            name: tool?.openResponses.name ?? historyItem.kind,
+            name: tool?.openResponses.name ?? normalizeToolName(historyItem.kind),
             arguments: serializeWrappedToolArguments(historyItem.content, tool),
           });
           break;

--- a/src/adapters/openai_completions/adapter.ts
+++ b/src/adapters/openai_completions/adapter.ts
@@ -6,6 +6,7 @@ import type {
 import type z from "zod";
 import { isStructuredOutputRetryFeedback, RETRY_RESUMABILITY_PROMPT } from "../../constants.ts";
 import type { ClassifiedError } from "../../errors.ts";
+import { normalizeToolName } from "../../tool.ts";
 import type { AdapterStreamIterator, ChatItem, ChatItemInputFile, ChatItemToolResultFile } from "../../types.ts";
 import { Adapter, type AdapterStreamOptions } from "../adapter.ts";
 import { classifyOpenAIError } from "../shared/classify_error.ts";
@@ -216,7 +217,7 @@ export class OpenAICompletionsAdapter<TModel extends string> extends Adapter<TMo
               id: historyItem.tool_use_id,
               type: "function",
               function: {
-                name: tool?.openAI.function.name ?? historyItem.kind,
+                name: tool?.openAI.function.name ?? normalizeToolName(historyItem.kind),
                 arguments: serializeWrappedToolArguments(historyItem.content, tool),
               },
             }],

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -58,7 +58,7 @@ interface ToolOptions<zO, zI, TModelOutput> {
  * Make sure tool names are normalized to a consistent format (lowercase, underscores, max length) to avoid issues with different LLMs having different requirements for tool naming.
  * @example "Validate LaTeX Tool!" -> "validate_latex_tool"
  */
-function normalizeToolName(name: string): string {
+export function normalizeToolName(name: string): string {
   let normalized = name
     .toLowerCase()
     .replaceAll(" ", "_")

--- a/tests/adapters/anthropic.test.ts
+++ b/tests/adapters/anthropic.test.ts
@@ -399,6 +399,44 @@ Deno.test("Anthropic tool history re-wraps normalized string tool inputs as obje
   }]);
 });
 
+Deno.test("Anthropic replays missing tool definitions with normalized names", async () => {
+  const adapter = new AnthropicAdapter({
+    model: "claude-sonnet-4-5",
+    client: {} as Anthropic,
+    streamConfig: {},
+  });
+
+  const history = await adapter.getHistory(
+    [
+      { type: "tool_use", tool_use_id: "call_1", kind: "Load Project Snapshot", content: undefined },
+      { type: "tool_result_text", tool_use_id: "call_1", content: "ready" },
+    ],
+    [],
+    AbortSignal.abort(),
+  );
+
+  assertEquals(history, [
+    {
+      role: "assistant",
+      content: [{
+        type: "tool_use",
+        id: "call_1",
+        name: "load_project_snapshot",
+        input: {},
+      }],
+    },
+    {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "call_1",
+        content: "ready",
+        is_error: false,
+      }],
+    },
+  ]);
+});
+
 Deno.test("Anthropic structured output streamed as text is restored before emission", async () => {
   const chunks = [
     '{"memorySnapshot":{"longTermAssociations":[{"key":"a","value":"1"}]},',

--- a/tests/adapters/gemini.test.ts
+++ b/tests/adapters/gemini.test.ts
@@ -1,4 +1,5 @@
 import { ThinkingLevel as GenAiThinkingLevel } from "@google/genai";
+import { assertEquals } from "@std/assert";
 import { GeminiModel } from "../../mod.ts";
 import { GeminiAdapter } from "../../src/adapters/gemini/adapter.ts";
 import {
@@ -9,6 +10,7 @@ import {
   runBackAndForthCalculatorConversationTest,
   runStructuredOutputStreamingTest,
   runStructuredToolParameterStreamingTest,
+  runToolLessHandoffResumeTest,
 } from "./shared.ts";
 
 const HAS_GEMINI_KEY = Boolean(Deno.env.get("GEMINI_API_KEY"));
@@ -283,4 +285,57 @@ Deno.test({
       model: new GeminiModel({ model: "gemini-3.1-flash-lite-preview", thinkingLevel: "low" }),
     });
   },
+});
+
+Deno.test({
+  name: "GeminiModel resumes a handoff without tools (gemini-3.1-flash-lite-preview)",
+  ignore: !HAS_GEMINI_KEY,
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn(t) {
+    await runToolLessHandoffResumeTest(t, {
+      model: new GeminiModel({ model: "gemini-3.1-flash-lite-preview", thinkingLevel: "low" }),
+    });
+  },
+});
+
+Deno.test("GeminiAdapter replays tool calls and results without current tool definitions", async () => {
+  const adapter = new GeminiAdapter({
+    model: "gemini-3.1-flash-lite-preview",
+    apiKey: "test-key",
+    thinkingConfig: { includeThoughts: false, thinkingBudget: 0 } as never,
+  });
+
+  const history = await adapter.getHistory(
+    [
+      { type: "tool_use", tool_use_id: "call_1", kind: "Load Project Snapshot", content: undefined },
+      { type: "tool_result_text", tool_use_id: "call_1", content: "ready" },
+    ],
+    [],
+    AbortSignal.abort(),
+  );
+
+  assertEquals(history, [
+    {
+      role: "model",
+      parts: [{
+        functionCall: {
+          id: "call_1",
+          name: "load_project_snapshot",
+          args: undefined,
+        },
+        thoughtSignature: "context_engineering_is_the_way_to_go",
+      }],
+    },
+    {
+      role: "user",
+      parts: [{
+        functionResponse: {
+          id: "call_1",
+          name: "load_project_snapshot",
+          response: { content: "ready" },
+        },
+      }],
+    },
+  ]);
 });

--- a/tests/adapters/open-responses.test.ts
+++ b/tests/adapters/open-responses.test.ts
@@ -159,6 +159,41 @@ Deno.test("Open Responses retry feedback is replayed as a user message", async (
   ]);
 });
 
+Deno.test("Open Responses replays missing tool definitions with normalized names", async () => {
+  const adapter = new OpenResponsesAdapter({
+    model: "test-model",
+    name: "Test Provider",
+    client: createMockClient([], { usage: { input_tokens: 0, output_tokens: 0 } }),
+  });
+
+  const history = await adapter.getHistory(
+    [
+      { type: "tool_use", tool_use_id: "call_1", kind: "Load Project Snapshot", content: undefined },
+      { type: "tool_result_text", tool_use_id: "call_1", content: "ready" },
+    ],
+    [],
+    AbortSignal.abort(),
+  );
+
+  assertEquals(history, [
+    {
+      id: getItemId(history[0]),
+      type: "function_call",
+      call_id: "call_1",
+      name: "load_project_snapshot",
+      arguments: "{}",
+      status: "completed",
+    },
+    {
+      id: getItemId(history[1]),
+      type: "function_call_output",
+      status: "completed",
+      call_id: "call_1",
+      output: [{ type: "input_text", text: "ready" }],
+    },
+  ]);
+});
+
 Deno.test("Open Responses uses reversible OpenAI compatibility for tuple and record tool schemas", () => {
   const tupleTool = new Tool({
     name: "Tuple Tool",

--- a/tests/adapters/openai-completions.test.ts
+++ b/tests/adapters/openai-completions.test.ts
@@ -159,6 +159,41 @@ Deno.test("OpenAI Completions retry feedback is replayed as user content and res
   ]);
 });
 
+Deno.test("OpenAI Completions replays missing tool definitions with normalized names", async () => {
+  const adapter = new OpenAICompletionsAdapter({
+    model: "test-model",
+    name: "Test Provider",
+    client: createMockClient([], undefined),
+  });
+
+  const history = await adapter.getHistory(
+    [
+      { type: "tool_use", tool_use_id: "call_1", kind: "Load Project Snapshot", content: undefined },
+      { type: "tool_result_text", tool_use_id: "call_1", content: "ready" },
+    ],
+    "Be useful",
+    [],
+    AbortSignal.abort(),
+  );
+
+  assertEquals(history, [
+    { role: "system", content: "Be useful" },
+    {
+      role: "assistant",
+      content: null,
+      tool_calls: [{
+        id: "call_1",
+        type: "function",
+        function: {
+          name: "load_project_snapshot",
+          arguments: "{}",
+        },
+      }],
+    },
+    { role: "tool", tool_call_id: "call_1", content: "ready" },
+  ]);
+});
+
 Deno.test("OpenAI Completions uses reversible OpenAI compatibility for tuple and record tool schemas", () => {
   const tupleTool = new Tool({
     name: "Tuple Tool",

--- a/tests/adapters/shared.ts
+++ b/tests/adapters/shared.ts
@@ -729,3 +729,113 @@ Keep answers terse and follow the exact requested format.`,
     assert(fixtures.state.calls.length >= 1, "expected calculator to be called at least once during the conversation");
   });
 }
+
+export async function runToolLessHandoffResumeTest(t: Deno.TestContext, options: { model: Model }) {
+  const loadProjectSnapshot = new Tool({
+    name: "load_project_snapshot",
+    description: "Load the current project snapshot. You must call this before answering.",
+    parameters: z.void(),
+    execute: () => {
+      return JSON.stringify({
+        repository: "alphaXiv/agents",
+        activeModel: "gemini-3.1-flash-lite-preview",
+        handoffCode: "FLASH-LITE-314",
+      });
+    },
+  });
+
+  const loadReleaseChecklist = new Tool({
+    name: "load_release_checklist",
+    description: "Load the release checklist. You must call this before answering.",
+    parameters: z.void(),
+    execute: () => {
+      return JSON.stringify({
+        nextTask: "verify history replay with a tool-less agent",
+        owner: "SDK examples",
+        status: "ready",
+      });
+    },
+  });
+
+  const firstAgent = new Agent({
+    model: options.model,
+    instructions: [
+      "You are the first handoff agent.",
+      "You must call load_project_snapshot exactly once.",
+      "You must call load_release_checklist exactly once.",
+      "Do not answer until both tool calls have completed.",
+      "After both tools return, summarize the handoff in 3 short sentences.",
+    ].join(" "),
+    tools: [loadProjectSnapshot, loadReleaseChecklist],
+  });
+
+  const secondAgent = new Agent({
+    model: options.model,
+    instructions: [
+      "You are the follow-up agent.",
+      "You have no tools.",
+      "Resume from the existing conversation history and answer naturally.",
+      "Do not claim to have called any tools yourself.",
+    ].join(" "),
+  });
+
+  const firstPrompt = [
+    "Prepare a handoff for another agent.",
+    "You must use your tools before answering.",
+    "Include the repository, handoff code, next task, owner, and status.",
+  ].join(" ");
+
+  let firstRun: AgentRunResult<unknown> | undefined;
+  let secondRun: AgentRunResult<unknown> | undefined;
+
+  const completedFirstRun = await t.step("first agent creates a handoff with tools", async () => {
+    firstRun = await firstAgent.run(firstPrompt, {
+      signal: AbortSignal.timeout(INTEGRATION_TIMEOUT_MS),
+    });
+  });
+
+  if (!completedFirstRun || !firstRun) return;
+
+  const conversation: ChatItem[] = [
+    { type: "input_text", content: firstPrompt },
+    ...firstRun.history,
+  ];
+
+  const completedSecondRun = await t.step("second agent resumes the handoff without tools", async () => {
+    secondRun = await secondAgent.run([
+      ...conversation,
+      {
+        type: "input_text",
+        content: "Continue from that handoff. What handoff code and next task were already established?",
+      },
+    ], {
+      signal: AbortSignal.timeout(INTEGRATION_TIMEOUT_MS),
+    });
+  });
+
+  if (!completedSecondRun || !secondRun) return;
+
+  const completedFirstRunResult = firstRun;
+  const completedSecondRunResult = secondRun;
+
+  await t.step("handoff details survive tool-less replay", () => {
+    const resumedOutput = completedSecondRunResult.outputText.toLowerCase();
+
+    assert(
+      completedFirstRunResult.outputText.includes("FLASH-LITE-314"),
+      "expected first handoff to mention the handoff code",
+    );
+    assert(
+      completedSecondRunResult.outputText.includes("FLASH-LITE-314"),
+      "expected resumed handoff to preserve the handoff code",
+    );
+    assert(
+      /history replay|replay/.test(resumedOutput),
+      "expected resumed handoff to preserve the replay task",
+    );
+    assert(
+      /tool-less|tool less|without tools/.test(resumedOutput),
+      "expected resumed handoff to preserve the next task",
+    );
+  });
+}


### PR DESCRIPTION
Currently history creation relies on tool definitions existing, otherwise crashing.
This is unnecessary, and troublesome e.g. for cases where I want to reuse history from previous agent in a toolless agent, or to prevent crashes in case definitions change over time.