### PR TITLE
fix: context compaction related issues

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -188,13 +188,13 @@ interface CompactionResult<T> {
 async function* consumeCompactionEvents<T extends ChatItem[] | null>(
   gen: AsyncGenerator<ContextSummaryStartEvent, T>,
   previousHistory: ChatItem[],
-  historyLength: number,
+  streamIndexOffset: number,
   traceId: string,
 ): AsyncGenerator<WithTraceId<StreamItem>, CompactionResult<T>> {
   // Forward any progress events from the compaction hook to the stream
   let next = await gen.next();
   while (!next.done) {
-    yield { type: "context_summary_start", index: historyLength, trace: traceId };
+    yield { type: "context_summary_start", index: streamIndexOffset, trace: traceId };
     next = await gen.next();
   }
 
@@ -217,7 +217,7 @@ async function* consumeCompactionEvents<T extends ChatItem[] | null>(
       compactionItems.push(tracedItem);
       yield {
         type: "context_summary",
-        index: historyLength + compactionItems.length - 1,
+        index: streamIndexOffset + compactionItems.length - 1,
         content: item.content,
         trace: traceId,
       };
@@ -500,7 +500,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
                 model: currentModel,
               }),
               baseHistory,
-              history.length,
+              history.length + turnItems.length,
               agentTrace.id,
             );
 
@@ -517,7 +517,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
               modelTrace,
               messageTracer,
               turnItems,
-              historyLength: history.length,
+              streamIndexOffset: history.length + turnItems.length + compactionItems.length,
             });
 
             // Only persist compaction items after the model succeeds. Using unshift ensures
@@ -546,7 +546,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
                   model: currentModel,
                 }),
                 baseHistory,
-                history.length,
+                history.length + turnItems.length,
                 agentTrace.id,
               );
 
@@ -597,7 +597,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
     modelTrace: ActiveTrace<"model">;
     messageTracer: MessageTracer;
     turnItems: WithTraceId<ChatItem>[];
-    historyLength: number;
+    streamIndexOffset: number;
   }): AsyncGenerator<WithTraceId<StreamItem>, { inputTokens: number; outputTokens: number; trace: string }> {
     const { adapter, signal, pendingTools, toolSignal, agentTrace, modelTrace, messageTracer, turnItems } = options;
 
@@ -658,7 +658,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
       }
 
       addStreamItem(turnItems, { ...part, trace });
-      yield { ...part, index: part.index + options.historyLength, trace };
+      yield { ...part, index: part.index + options.streamIndexOffset, trace };
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,12 +67,16 @@ function createChatItemFromStreamItem(streamItem: StreamItem): ChatItem {
         kind: streamItem.kind,
         content: streamItem.content,
       };
+    case "context_summary":
+      return {
+        type: "context_summary",
+        content: streamItem.content,
+      };
     case "token_usage":
     case "context_summary_start":
-    case "context_summary":
     case "model_switched":
       throw new Error(
-        `Context summary items cannot be unambiguously converted into ChatItem. Spotted "${streamItem.type}".`,
+        `Cannot convert informational stream item "${streamItem.type}" into ChatItem.`,
       );
   }
 }
@@ -93,7 +97,6 @@ export function addStreamItem<T extends ChatItem>(
   if (
     streamItem.type === "token_usage" ||
     streamItem.type === "context_summary_start" ||
-    streamItem.type === "context_summary" ||
     streamItem.type === "model_switched"
   ) {
     return;

--- a/tests/simple/agent.test.ts
+++ b/tests/simple/agent.test.ts
@@ -512,6 +512,34 @@ Deno.test("beforeModelCall compaction items appear before model output in histor
   assert(summaryIndex < outputIndex, "context_summary should appear before output_text");
 });
 
+Deno.test("stream indices stay distinct after beforeModelCall compaction", async () => {
+  const agent = new Agent({
+    model: new DeterministicTestModel(),
+    instructions: "You are a friendly assistant",
+    async *beforeModelCall(history, _context) {
+      yield { type: "context_summary_start" };
+      return [
+        { type: "context_summary", content: "Summary of prior context" },
+        ...history,
+      ];
+    },
+  });
+
+  const streamItems: StreamItem[] = [];
+
+  for await (const item of agent.stream([{ type: "input_text", content: "Hello" }])) {
+    streamItems.push(item);
+  }
+
+  const summaryItem = streamItems.find((item) => item.type === "context_summary");
+  const firstOutputItem = streamItems.find((item) => item.type === "delta_output_text");
+
+  assert(summaryItem, "Should stream a context_summary item");
+  assert(firstOutputItem, "Should stream a delta_output_text item");
+  assertEquals(summaryItem.index, 0);
+  assertEquals(firstOutputItem.index, 1);
+});
+
 Deno.test("compaction items are only added after successful model call", async () => {
   let beforeModelCallCount = 0;
 

--- a/tests/simple/client.test.ts
+++ b/tests/simple/client.test.ts
@@ -135,3 +135,68 @@ Deno.test("addStreamItem keeps chat history dense while reordering", () => {
     { type: "output_text", content: "later again" },
   ]);
 });
+
+Deno.test("addStreamItem adds context_summary items into the chat item list", () => {
+  const chatItems: ChatItem[] = [];
+
+  addStreamItem(chatItems, {
+    type: "context_summary",
+    index: 0,
+    content: "Earlier context compacted.",
+  });
+
+  assertEquals(chatItems, [{
+    type: "context_summary",
+    content: "Earlier context compacted.",
+  }]);
+});
+
+Deno.test("addStreamItem ignores informational compaction and model switch events", () => {
+  const chatItems: ChatItem[] = [];
+
+  addStreamItem(chatItems, {
+    type: "context_summary_start",
+    index: 0,
+  });
+  addStreamItem(chatItems, {
+    type: "model_switched",
+    index: 0,
+    from: { provider: "gemini", model: "gemini-3.1-flash-lite-preview" },
+    to: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  });
+
+  assertEquals(chatItems, []);
+});
+
+Deno.test("addStreamItem preserves stream ordering when a summary precedes later deltas", () => {
+  const chatItems: WithTraceId<ChatItem>[] = [];
+
+  addStreamItem(
+    chatItems,
+    {
+      type: "delta_output_text",
+      index: 1,
+      delta: "Final answer",
+      trace: "trace-output",
+    } satisfies WithTraceId<StreamItem>,
+  );
+  addStreamItem(
+    chatItems,
+    {
+      type: "context_summary",
+      index: 0,
+      content: "Compact summary",
+      trace: "trace-summary",
+    } satisfies WithTraceId<StreamItem>,
+  );
+
+  assertEquals(chatItems, [{
+    type: "context_summary",
+    content: "Compact summary",
+    trace: "trace-summary",
+  }, {
+    type: "output_text",
+    content: "Final answer",
+    trace: "trace-output",
+  }]);
+});


### PR DESCRIPTION
1. `"context_summary"` is a chat item, it should be persisted
2. Emit correct indices linearly after compaction happens
3. Bad error message (guh)