### PR TITLE
fix: don't retry a failed provider / anthropic bug

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphaxiv/agents",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "license": "MIT",
   "fmt": {
     "lineWidth": 120

--- a/src/adapters/anthropic/history.ts
+++ b/src/adapters/anthropic/history.ts
@@ -2,6 +2,7 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { isStructuredOutputRetryFeedback } from "../../constants.ts";
 import { normalizeToolName } from "../../tool.ts";
 import type { ChatItem } from "../../types.ts";
+import { ensureToolInputObject } from "../shared/tools.ts";
 import type { AnthropicToolMap } from "./utils.ts";
 
 const supportedImageMimeTypes = ["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"];
@@ -85,7 +86,7 @@ export async function getAnthropicHistory(options: {
             type: "tool_use",
             id: historyItem.tool_use_id,
             name: tool?.anthropic.name ?? normalizeToolName(historyItem.kind),
-            input: tool?.compatibility ? tool.compatibility.toProvider(content) : content,
+            input: ensureToolInputObject(tool?.compatibility ? tool.compatibility.toProvider(content) : content),
           }],
         });
         break;

--- a/src/adapters/shared/tools.ts
+++ b/src/adapters/shared/tools.ts
@@ -9,6 +9,22 @@ export interface SharedToolShape {
   compatibility?: SharedSchemaCompatibility;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A tool call's `input` must be a JSON object; providers such as Anthropic reject
+ * a bare scalar with `input: Input should be an object`. A wrapper-object tool
+ * stores only its inner value, so replaying that call after the tool is no longer
+ * registered (nothing left to re-wrap it) would surface the scalar. Wrap stray
+ * non-objects under `content`, mirroring the wrapper shape.
+ */
+export function ensureToolInputObject(value: unknown): Record<string, unknown> {
+  if (isPlainObject(value)) return value;
+  return value === undefined ? {} : { content: value };
+}
+
 export function serializeWrappedToolArguments(content: string | undefined, tool: SharedToolShape | undefined): string {
   if (tool?.isVoid) return "{}";
   if (!content) return "{}";
@@ -21,8 +37,16 @@ export function serializeWrappedToolArguments(content: string | undefined, tool:
     }
   }
 
-  if (!tool?.wrapperObject) return content;
-  return `{"content":${content}}`;
+  if (tool?.wrapperObject) return `{"content":${content}}`;
+
+  // Known object tool → `content` is already an object; an unregistered tool
+  // (tool === undefined) may hold a wrapper tool's scalar. Guarantee an object.
+  try {
+    const parsed = JSON.parse(content);
+    return isPlainObject(parsed) ? content : JSON.stringify(ensureToolInputObject(parsed));
+  } catch {
+    return content;
+  }
 }
 
 export function restoreWrappedToolArguments(content: string, tool: SharedToolShape | undefined): string | undefined {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -8,6 +8,7 @@ import { createStructuredOutputRetryFeedback } from "./constants.ts";
 import { type ClassifiedError, classifyError, createClassifiedError, FirstTokenTimeoutError } from "./errors.ts";
 import {
   determineRetryBehavior,
+  isDeterministicModelError,
   type ResolvedRetryStrategy,
   resolveRetryStrategy,
   type RetryStrategy,
@@ -349,6 +350,11 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
       const history: WithTraceId<ChatItem>[] = [];
       let modelCallReason: ModelCallReason = "init";
 
+      // Indices into #models that failed this run with a deterministic (input-level)
+      // error. Skipped on later turns so the run stops re-paying a call that is
+      // guaranteed to fail identically.
+      const deadModels = new Set<number>();
+
       for (let turn = 0; turn < this.#maxTurns; turn++) {
         signal.throwIfAborted();
 
@@ -364,6 +370,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
             modelCallReason,
             turn,
             usage,
+            deadModels,
           });
 
         usage.totalInputTokens += inputTokens;
@@ -453,6 +460,7 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
     modelCallReason: ModelCallReason;
     turn: number;
     usage: TokenUsage;
+    deadModels: Set<number>;
   }): AsyncGenerator<
     WithTraceId<StreamItem>,
     ModelCallTokens & { turnItems: WithTraceId<ChatItem>[]; trace: string }
@@ -481,6 +489,14 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
 
       modelLoop: while (currentModelIndex < this.#models.length) {
         const adapter = this.#models[currentModelIndex];
+
+        // Skip a retired model only while a viable fallback remains, so an all-dead
+        // list still attempts (and surfaces the real error) rather than skipping past.
+        if (options.deadModels.has(currentModelIndex) && options.deadModels.size < this.#models.length) {
+          currentModelIndex++;
+          continue modelLoop;
+        }
+
         const currentModel: ModelInfo = { provider: adapter.provider, model: adapter.model };
 
         // Only guard time-to-first-token when there is somewhere to fall back to. The final
@@ -568,6 +584,12 @@ export class Agent<zO = unknown, zI = unknown, const Tools extends AnyTool[] = [
               ? createClassifiedError("timeout", error)
               : adapter.classifyError?.(error) ?? classifyError(error);
             agentTrace.log(`Model ${adapter.model} failed (${classified.kind}): ${errMessage(error)}`, error);
+
+            // A deterministic (input-level) failure recurs on every later turn, so
+            // retire this model as a candidate for the rest of the run.
+            if (isDeterministicModelError(classified.kind)) {
+              options.deadModels.add(currentModelIndex);
+            }
 
             const behavior = determineRetryBehavior(classified, this.#retryStrategy, sameModelRetries);
 

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -3,6 +3,23 @@ import type { ClassifiedError, ErrorKind } from "./errors.ts";
 /** Retry behavior options for different error types. */
 export type RetryBehavior = "retry-same" | "switch-model" | "no-retry";
 
+/**
+ * Error kinds that are a deterministic property of the (model, request) pair
+ * rather than a transient condition. Because an agent's history only grows, a
+ * model that rejects the request this way will reject it identically on every
+ * later turn, so it should be skipped for the rest of the run instead of being
+ * re-attempted (and re-failed) as the primary each turn.
+ */
+const DETERMINISTIC_ERROR_KINDS = new Set<ErrorKind>([
+  "client",
+  "unsupported_file_type",
+  "image_too_large",
+]);
+
+export function isDeterministicModelError(kind: ErrorKind): boolean {
+  return DETERMINISTIC_ERROR_KINDS.has(kind);
+}
+
 /** Configuration for retry behavior. All fields are optional with sensible defaults. */
 export interface RetryStrategy {
   /**

--- a/tests/adapters/anthropic.test.ts
+++ b/tests/adapters/anthropic.test.ts
@@ -443,6 +443,32 @@ Deno.test("Anthropic tool history re-wraps normalized string tool inputs as obje
   }]);
 });
 
+Deno.test("Anthropic wraps a scalar tool input whose tool is no longer registered", async () => {
+  // A wrapper-object tool call authored by another provider stores its inner scalar.
+  // Replayed once the tool is gone (nothing to re-wrap it), the raw scalar would make
+  // Anthropic reject the request with "tool_use.input: Input should be an object".
+  const history = await getAnthropicHistory({
+    history: [{
+      type: "tool_use",
+      tool_use_id: "call_1",
+      kind: "search_web",
+      content: '"habitat challenge dataset"',
+    }],
+    normalizedTools: [],
+    signal: AbortSignal.abort(),
+  });
+
+  assertEquals(history, [{
+    role: "assistant",
+    content: [{
+      type: "tool_use",
+      id: "call_1",
+      name: "search_web",
+      input: { content: "habitat challenge dataset" },
+    }],
+  }]);
+});
+
 Deno.test("Anthropic replays missing tool definitions with normalized names", async () => {
   const history = await getAnthropicHistory({
     history: [

--- a/tests/simple/agent.test.ts
+++ b/tests/simple/agent.test.ts
@@ -3,6 +3,7 @@ import { assertObjectMatch } from "@std/assert/object-match";
 import { delay } from "@std/async/delay";
 import z from "zod";
 import { Agent, type ChatItem, type StreamItem, Tool } from "../../mod.ts";
+import type { Adapter } from "../../src/adapters/adapter.ts";
 import {
   contextWindowTestModel,
   deterministicTestModel,
@@ -613,4 +614,40 @@ Deno.test("token_usage event is emitted after a successful model call", async ()
     totalCacheReadTokens: 0,
     totalCacheWriteTokens: 0,
   });
+});
+
+Deno.test("a deterministic client error retires a model for the rest of the run", async () => {
+  let primaryCalls = 0;
+  const clientErrorModel: Adapter<unknown, unknown> = {
+    provider: "primary",
+    model: "primary",
+    stream() {
+      primaryCalls += 1;
+      throw Object.assign(
+        new Error("400 invalid_request_error: tool_use.input: Input should be an object"),
+        { status: 400 },
+      );
+    },
+  };
+
+  const searchTool = new Tool({
+    name: "Searching the internet...",
+    description: "Search the internet",
+    parameters: z.string(),
+    execute: () => "search done",
+  });
+
+  const agent = new Agent({
+    model: [clientErrorModel, deterministicTestModel()],
+    instructions: "You are a friendly assistant",
+    tools: [searchTool],
+    retryStrategy: { modelCycles: 1, sameModelRetries: 0 },
+  });
+
+  const run = await agent.run("Find me something");
+
+  // Turn 1 fails the primary over to the fallback (which runs the tool). Turn 2 must
+  // skip the primary rather than re-pay its guaranteed 400, so it is called only once.
+  assertEquals(primaryCalls, 1);
+  assertObjectMatch(run.history.at(-1)!, { type: "output_text", content: "search done" });
 });


### PR DESCRIPTION
Two independent fallback bugs surfaced by a cross-provider agent run where Anthropic 400d and every turn silently fell back to Gemini.

1. Tool input wrapping. A wrapper-object tool (non-object top-level schema) stores only its inner value. When that call is replayed after the tool is no longer registered, nothing re-wraps it, so the raw scalar reached Anthropic as tool_use.input and was rejected with "Input should be an object". Add a shared ensureToolInputObject that wraps stray non-objects under `content`, and route both the Anthropic history serializer and the shared serializeWrappedToolArguments (which had the same unregistered-tool gap) through the guarantee. Not adapter-specific.

2. Fallback latency. A deterministic input-level error (4xx client, unsupported_file_type, image_too_large) recurs on every later turn because history only grows, yet each turn restarted the fallback list at the primary and re-paid the guaranteed failure. Track such models per run and skip them as long as a viable fallback remains.

Assisted-by: claude-opus-4.8