### PR TITLE
fix: stop sending strict tools to Anthropic by default

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphaxiv/agents",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "license": "MIT",
   "fmt": {
     "lineWidth": 120

--- a/src/adapters/anthropic/adapter.ts
+++ b/src/adapters/anthropic/adapter.ts
@@ -81,6 +81,18 @@ export function anthropicModel<zO, zI, TModel extends AnthropicModels>(options: 
    * assuming a hit.
    */
   cache?: boolean | AnthropicCacheOptions;
+  /**
+   * Compile the tool schemas into a decoding grammar so arguments are guaranteed to validate.
+   *
+   * Off by default: Anthropic compiles every strict tool on the request into one grammar and rejects
+   * the whole request with "The compiled grammar is too large" past an undocumented ceiling, which a
+   * dozen ordinary tools already clear on 4.6-generation models. Only worth enabling for a small,
+   * fixed toolset.
+   *
+   * Structured output compiles into that same grammar on models that support it natively, so an
+   * agent with a large output schema can reach the ceiling with this off.
+   */
+  strictTools?: boolean;
   baseUrl?: string;
   apiKey?: string;
   client?: Anthropic;
@@ -145,7 +157,7 @@ ${JSON.stringify(structuredOutput.originalJsonSchema, null, 2)}
     stream: async function* stream<zO, zI>(
       { history, instructions, tools, signal, output, cache: cacheDefault }: AdapterStreamOptions<zO, zI>,
     ): AdapterStreamIterator {
-      const normalizedTools = normalizeAnthropicTools(tools);
+      const normalizedTools = normalizeAnthropicTools(tools, options.strictTools);
       const anthropicHistory = await getAnthropicHistory({ history, normalizedTools, signal });
 
       // Tools mean an agent loop, which rereads its prefix every turn and profits from caching.

--- a/src/adapters/anthropic/utils.ts
+++ b/src/adapters/anthropic/utils.ts
@@ -39,6 +39,7 @@ export const anthropicSchemaCompatibilityFeatures: SchemaCompatibilityFeatures =
   },
   strings: {
     length: "instructions",
+    format: "instructions",
   },
   numbers: {
     integerType: "number",
@@ -50,7 +51,7 @@ export const anthropicSchemaCompatibilityFeatures: SchemaCompatibilityFeatures =
   },
 };
 
-export function normalizeAnthropicTools(tools: AnyTool[]): AnthropicToolMap[] {
+export function normalizeAnthropicTools(tools: AnyTool[], strict = false): AnthropicToolMap[] {
   return tools.map((tool): AnthropicToolMap => {
     const name = tool.normalizedName;
 
@@ -78,7 +79,7 @@ export function normalizeAnthropicTools(tools: AnyTool[]): AnthropicToolMap[] {
       original: tool,
       anthropic: {
         name,
-        strict: true,
+        strict,
         eager_input_streaming: true,
         input_schema: compatibleSchema.jsonSchema,
         description: compatibleSchema.instructions

--- a/src/adapters/shared/openai_compatibility.ts
+++ b/src/adapters/shared/openai_compatibility.ts
@@ -30,6 +30,7 @@ export const openAISchemaCompatibilityFeatures: SchemaCompatibilityFeatures = {
   },
   strings: {
     length: "instructions",
+    format: "native",
   },
   numbers: {
     integerType: "number",

--- a/src/adapters/shared/schema_compatibility.ts
+++ b/src/adapters/shared/schema_compatibility.ts
@@ -42,6 +42,11 @@ export interface SchemaCompatibilityFeatures {
   };
   strings: {
     length: "native" | "instructions";
+    /**
+     * Named formats (`uri`, `date`, `uuid`, ...) and regex patterns. Providers that compile schemas
+     * into a decoding grammar pay for them, and Zod's date format alone spells out every leap year.
+     */
+    format: "native" | "instructions";
   };
   numbers: {
     integerType: "native" | "number";
@@ -313,16 +318,24 @@ function transformStringSchema(schema: ZodJsonSchema, path: string, context: Com
     }
   }
 
-  const transformed = context.features.strings.length === "instructions"
-    ? omitSchemaKeywords(schema, ["minLength", "maxLength"])
-    : { ...schema };
+  const omitted = context.features.strings.length === "instructions" ? ["minLength", "maxLength"] : [];
+  const describesFormat = context.features.strings.format === "instructions";
+  const format = describesFormat && typeof schema.format === "string" ? schema.format : undefined;
+  const pattern = describesFormat && typeof schema.pattern === "string" ? schema.pattern : undefined;
+  if (format || pattern) omitted.push("format", "pattern");
 
   if (constraints.length > 0) {
     context.constraints.push(`- \`${path}\` must have ${constraints.join(" and ")}`);
   }
+  // A named format already says what its pattern spells out, so the regex itself stays out of the prompt.
+  if (format) {
+    context.constraints.push(`- \`${path}\` must be a valid ${format}`);
+  } else if (pattern) {
+    context.constraints.push(`- \`${path}\` must match \`${pattern}\``);
+  }
 
   return {
-    jsonSchema: transformed,
+    jsonSchema: omitSchemaKeywords(schema, omitted),
     toProvider: identity,
     fromProvider: identity,
   };
@@ -587,6 +600,9 @@ function stripUnsupportedKeywords(schema: ZodJsonSchema, context: CompatibilityC
         case "minLength":
         case "maxLength":
           return context.features.strings.length === "instructions" ? [] : [[key, value]];
+        case "format":
+        case "pattern":
+          return context.features.strings.format === "instructions" ? [] : [[key, value]];
         case "maxItems":
           return context.features.arrays.length === "native" ? [[key, value]] : [];
         case "minItems":
@@ -831,8 +847,10 @@ function schemaTypeToString(schema: ZodJsonSchemaInput | ZodJsonSchemaInput[] | 
       return `${schemaTypeToString(schema.items)}[]`;
     case "integer":
       return "integer";
-    case "number":
+    // Record keys never reach transformStringSchema, so this string is the only place their format can land.
     case "string":
+      return typeof schema.format === "string" ? schema.format : type;
+    case "number":
     case "boolean":
     case "null":
       return type;

--- a/tests/adapters/anthropic.test.ts
+++ b/tests/adapters/anthropic.test.ts
@@ -426,6 +426,38 @@ Deno.test("tool schemas can be wrapped to satisfy Anthropic top-level object req
   assert(compatibility.instructions.includes("at least 2 characters"));
 });
 
+Deno.test("string formats are described in instructions instead of the schema", () => {
+  const compatibility = createAnthropicCompatibleSchema(
+    z.object({ url: z.url(), day: z.iso.date(), slug: z.string().regex(/^[a-z]+$/) }),
+    {
+      kind: "tool",
+      requireTopLevelObject: true,
+      rootPath: "input",
+    },
+  );
+
+  assertEquals(compatibility.jsonSchema.properties, {
+    url: { type: "string" },
+    day: { type: "string" },
+    slug: { type: "string" },
+  });
+  assert(compatibility.instructions.includes("`input.url` must be a valid uri"));
+  assert(compatibility.instructions.includes("`input.day` must be a valid date"));
+  assert(compatibility.instructions.includes("`input.slug` must match `^[a-z]+$`"));
+});
+
+Deno.test("tools are not strict unless the caller opts in", () => {
+  const tool = new Tool({
+    name: "search",
+    description: "A tool",
+    parameters: z.object({ query: z.string() }),
+    execute: () => "ok",
+  });
+
+  assertEquals(normalizeAnthropicTools([tool])[0].anthropic.strict, false);
+  assertEquals(normalizeAnthropicTools([tool], true)[0].anthropic.strict, true);
+});
+
 Deno.test("Anthropic retry feedback is replayed as a user message", async () => {
   const history = await getAnthropicHistory({
     history: [

--- a/tests/adapters/openai-completions.test.ts
+++ b/tests/adapters/openai-completions.test.ts
@@ -261,6 +261,20 @@ Deno.test("OpenAI Completions uses reversible OpenAI compatibility for tuple and
   assert(normalizedTool?.openAI.function.description?.includes("<input_requirements>"));
 });
 
+Deno.test("OpenAI Completions keeps string formats in the tool schema", () => {
+  const [normalizedTool] = normalizeOpenAICompletionsTools([
+    new Tool({
+      name: "Fetch Page",
+      description: "Reads a url",
+      parameters: z.object({ url: z.url() }).strict(),
+      execute: () => "unused",
+    }),
+  ]);
+
+  const parameters = normalizedTool?.openAI.function.parameters as { properties?: Record<string, unknown> };
+  assertEquals(parameters.properties?.url, { type: "string", format: "uri" });
+});
+
 Deno.test("OpenAI Completions restores structured output from OpenAI-compatible surrogate shapes", async () => {
   let capturedRequest: unknown;
 


### PR DESCRIPTION
Anthropic compiles every strict tool schema on a request into one decoding grammar and rejects the whole request with "The compiled grammar is too large" past an undocumented ceiling. alphaXiv's 13-tool assistant clears it, so every turn 400d on claude-sonnet-4-6 while the same payload compiled fine on claude-sonnet-5. Trimming enums, descriptions or whole schema keywords never got under it; only deleting tools did.

Strict is now off unless a model opts in with `strictTools`, which is only realistic for a small fixed toolset. Losing it costs little in practice: it only shapes arguments once the model has already decided to call a tool, and a 39-query researcher corpus on claude-sonnet-4-6 with strict off produced 151 tool calls with zero rejected arguments and zero invented researcher links, matching the recorded gpt-5.6 baseline.

String formats and their regex patterns also move into the prompt instructions for Anthropic, next to the length and numeric bounds already handled that way. Zod pairs z.iso.date() with a leap-year-aware regex that a grammar has to compile literally, and "must be a valid date" says the same thing. OpenAI keeps them native.

Assisted-by: claude-opus-5