### PR TITLE
fix: disable strict tool calls via opencompletions api

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphaxiv/agents",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "license": "MIT",
   "fmt": {
     "lineWidth": 120

--- a/src/adapters/openai_completions/tools.ts
+++ b/src/adapters/openai_completions/tools.ts
@@ -61,7 +61,7 @@ export function normalizeOpenAICompletionsTools(tools: AnyTool[]): OpenAIComplet
           description: compatibility.instructions
             ? `${tool.description}\n\n${compatibility.instructions}`
             : tool.description,
-          strict: true,
+          strict: false,
           parameters: compatibility.jsonSchema,
         },
       },

--- a/tests/adapters/openai-completions.test.ts
+++ b/tests/adapters/openai-completions.test.ts
@@ -437,7 +437,7 @@ Deno.test("OpenAI Completions stream maps text, reasoning, and tool calls", asyn
       function: {
         name: "search",
         description: "Search for documents",
-        strict: true,
+        strict: false,
         parameters: {
           type: "object",
           properties: {


### PR DESCRIPTION
Temporary workaround for GPT-5.6 via OpenRouter failing due to optionality in the schema