### PR TITLE
fix: textlike `application/*` files on Anthropic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@alphaxiv/agents",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "license": "MIT",
   "fmt": {
     "lineWidth": 120

--- a/src/adapters/anthropic/history.ts
+++ b/src/adapters/anthropic/history.ts
@@ -2,10 +2,9 @@ import type Anthropic from "@anthropic-ai/sdk";
 import { isStructuredOutputRetryFeedback } from "../../constants.ts";
 import { normalizeToolName } from "../../tool.ts";
 import type { ChatItem } from "../../types.ts";
+import { IMAGE_MIME_TYPES, isTextLikeMimeType } from "../shared/media.ts";
 import { ensureToolInputObject } from "../shared/tools.ts";
 import type { AnthropicToolMap } from "./utils.ts";
-
-const supportedImageMimeTypes = ["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"];
 
 // TODO: drop signature after 10 minutes or whatever
 // Mapping between thinking response and signature since signature is meaningless cross-provider and we technically only need to include thinking for the one step
@@ -135,7 +134,7 @@ export async function getAnthropicHistory(options: {
       case "input_file":
       case "tool_result_file": {
         const pushBuffer = historyItem.type === "input_file" ? anthropicHistory : anthropicToolFileBuffer;
-        if (supportedImageMimeTypes.includes(historyItem.kind)) {
+        if ((IMAGE_MIME_TYPES as readonly string[]).includes(historyItem.kind)) {
           pushBuffer.push({
             role: "user",
             content: [{
@@ -159,7 +158,7 @@ export async function getAnthropicHistory(options: {
               },
             ],
           });
-        } else if (historyItem.kind.startsWith("text/")) {
+        } else if (isTextLikeMimeType(historyItem.kind)) {
           const req = await fetch(historyItem.content, { signal: options.signal });
           const text = await req.text();
 

--- a/tests/adapters/anthropic.test.ts
+++ b/tests/adapters/anthropic.test.ts
@@ -1,5 +1,5 @@
 import type Anthropic from "@anthropic-ai/sdk";
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import z from "zod";
 import { addStreamItem, Agent, type AnyTool, type ChatItem, type StreamItem, Tool } from "../../mod.ts";
 import { anthropicModel } from "../../src/adapters/anthropic/adapter.ts";
@@ -1177,4 +1177,37 @@ Deno.test("Agent cache option reaches the Anthropic adapter", async () => {
 
   assertEquals(tailCacheControl(await runAgent(undefined)), { type: "ephemeral", ttl: undefined });
   assertEquals(tailCacheControl(await runAgent(false)), undefined);
+});
+
+Deno.test("textlike application/* files are inlined instead of rejected", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => Promise.resolve(new Response('{"cats": 2}'))) as typeof fetch;
+
+  try {
+    const history = await getAnthropicHistory({
+      history: [{ type: "input_file", kind: "application/json", content: "https://example.com/cats.json" }],
+      normalizedTools: [],
+      signal: AbortSignal.abort(),
+    });
+
+    assertEquals(history, [{
+      role: "user",
+      content: [{ type: "text", text: '<ant-file>{"cats": 2}</ant-file>' }],
+    }]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("non-textlike media types are still rejected", async () => {
+  await assertRejects(
+    () =>
+      getAnthropicHistory({
+        history: [{ type: "input_file", kind: "video/mp2t", content: "https://example.com/cats.ts" }],
+        normalizedTools: [],
+        signal: AbortSignal.abort(),
+      }),
+    Error,
+    "video/mp2t",
+  );
 });


### PR DESCRIPTION
- Fixed the Anthropic adapter throwing on textlike application/* files (json, xml, yaml)
- Bumped to 0.6.14